### PR TITLE
Disallow closures with zero arguments

### DIFF
--- a/examples/closure.stt
+++ b/examples/closure.stt
@@ -13,3 +13,6 @@
 arr$filter
 
 prt
+
+[]{}
+prt

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -83,6 +83,17 @@ impl Context {
                 }
 
                 (Nothing, FnArgs(args)) => MakeClosureBlock(args),
+                (MakeClosureBlock(empty_args), Block(code)) if empty_args.is_empty() => {
+                    match code.first().and_then(|first| Some((first, code.last()?)) ) {
+                        Some((first, last)) => {
+                            let span = first.span.start .. last.span.end;
+                            panic!("Can't make closure with zero arguments, it's code spans this: {span:?}")
+                        },
+                        None => {
+                            panic!("Can't make closure with zero arguments")
+                        }
+                    }
+                }
                 (MakeClosureBlock(args), Block(code)) => {
                     let mut inner_ctx = Context::new(code);
                     let code = inner_ctx.parse_block()?;


### PR DESCRIPTION
Disallow closures with zero arguments
Fixes #2

- **parse: disable closures with zero arguments**
- **examples/closure: test error with parsing closures**
