### PR TITLE
User functions into closures

### DIFF
--- a/examples/closure.stt
+++ b/examples/closure.stt
@@ -3,16 +3,22 @@
 (pragma set debug)
 (include stdlib)
 
-<arr>
-1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 ,
-</arr>
+(fn) [a] double { a 2 * }
+(fn) [a] add-one { a ++ }
+(fn) [ cl-b cl-a ] cl$joinr {
+	[ cl-a cl-b x ] {
+		cl-b cl-a x @ @
+	} cl-a @ cl-b @
+}
 
-[a]{ a 2 % 0 = }
+(fn) [ cl-a cl-b ] cl$joinl {
+	[ cl-a cl-b x ] {
+		cl-b cl-a x @ @
+	} cl-a @ cl-b @
+}
 
+(@add-one) (@double) cl$joinr 4 @ prt
+(@double) (@add-one) cl$joinl 4 @ prt
 
-arr$filter
+(@double) (@add-one) (@double) cl$joinl cl$joinl 4 @ prt
 
-prt
-
-[]{}
-prt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,10 @@ pub enum SttError {
         index: usize,
         removed: Value,
     },
+    #[error(
+        "Can't make function ({fn_name}) that takes entire stack into closure, since it would never be executed"
+    )]
+    CantMakeIntoClosure { fn_name: String },
 }
 
 #[derive(Clone, Debug)]
@@ -305,6 +309,18 @@ pub struct FnDef {
 impl FnDef {
     pub fn new(scope: FnScope, code: Vec<Expr>, args: FnArgs) -> Self {
         FnDef { scope, code, args }
+    }
+    pub fn into_closure(self, name: &str) -> Result<Closure> {
+        let args = match self.args {
+            FnArgs::AllStack => Err(SttError::CantMakeIntoClosure {
+                fn_name: name.to_string(),
+            }),
+            FnArgs::Args(a) => Ok(a),
+        }?;
+        Ok(Closure {
+            code: self.code,
+            request_args: ClosurePartialArgs::new(args),
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub enum SttError {
     CantReadFile(PathBuf),
     #[error("No such function or function argument called `{0}`")]
     MissingIdent(String),
-    #[error("No such function `{0}`")]
-    MissingFunction(String),
+    #[error("No such user-defined function `{0}`")]
+    MissingUserFunction(String),
     #[error("WrongStackSizeDiffOnCheck {old_stack_size} -> {new_stack_size}")]
     WrongStackSizeDiffOnCheck {
         old_stack_size: usize,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -87,25 +87,12 @@ impl Context {
                 }
 
                 (Nothing, FnArgs(args)) => MakeClosureBlock(args),
-                (MakeClosureBlock(empty_args), Block(code)) if empty_args.is_empty() => {
-                    match code.first().and_then(|first| Some((first, code.last()?))) {
-                        Some((first, last)) => {
-                            let span = first.span.start..last.span.end;
-                            panic!(
-                                "Can't make closure with zero arguments, it's code spans this: {span:?}"
-                            )
-                        }
-                        None => {
-                            panic!("Can't make closure with zero arguments")
-                        }
-                    }
-                }
                 (MakeClosureBlock(args), Block(code)) => {
                     let mut inner_ctx = Context::new(code);
                     let code = inner_ctx.parse_block()?;
                     let closure = Closure {
                         code,
-                        request_args: ClosurePartialArgs::new(args),
+                        request_args: ClosurePartialArgs::parse(args, span.clone())?,
                     };
                     push_expr!(E::Immediate(Value::Closure(Box::new(closure))));
                     Nothing

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -75,6 +75,10 @@ impl Context {
                     push_expr!(E::Keyword(KeywordKind::BubbleError));
                     Nothing
                 }
+                (Nothing, Keyword(RawKeyword::FnIntoClosure { fn_name })) => {
+                    push_expr!(E::Keyword(KeywordKind::IntoClosure { fn_name: fn_name }));
+                    Nothing
+                }
 
                 (s, IncludedBlock(code)) => {
                     let mut inner_ctx = Context::new(code.tokens);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -114,6 +114,15 @@ impl Context {
 
     fn execute_kw(&mut self, kw: &KeywordKind, source: &Path) -> Result<ControlFlow> {
         Ok(match kw {
+            KeywordKind::IntoClosure { fn_name } => {
+                let fndef = self
+                    .fns
+                    .get(fn_name)
+                    .ok_or(SttError::MissingUserFunction(fn_name.as_str().to_string()))?;
+                let closure = fndef.into_closure(fn_name.as_str())?;
+                self.stack.push_this(closure);
+                ControlFlow::Continue
+            }
             KeywordKind::BubbleError => {
                 let e = stack_pop!((self.stack) -> result as "result" for "(!) keyword")?;
                 match e {

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-use crate::{FnScope, RawKeyword, Result, Token, TokenCont};
+use crate::{FnScope, RawKeyword, Result, SttError, Token, TokenCont};
 
 pub struct Context {
     point: usize,
@@ -137,15 +137,23 @@ impl Context {
                         "switch" => RawKeyword::Switch,
                         "break" => RawKeyword::Break,
                         "ifs" => RawKeyword::Ifs,
-                        _ if buf.starts_with("include ") => RawKeyword::Include {
-                            path: buf.split_once(" ").unwrap().1.trim().into(),
-                        },
-                        _ if buf.starts_with("pragma ") => RawKeyword::Pragma {
-                            command: buf.split_once(" ").unwrap().1.trim().into(),
-                        },
-                        _ => {
-                            eprintln!("unknown keyword {buf}");
-                            return Err(crate::SttError::TodoErr);
+                        otherwise => {
+                            let include =
+                                otherwise
+                                    .strip_prefix("include ")
+                                    .map(|p| RawKeyword::Include {
+                                        path: p.trim().into(),
+                                    });
+                            let pragma = otherwise
+                                .strip_prefix("pragma ")
+                                .map(|c| RawKeyword::Pragma { command: c.into() });
+                            let fn_into_closure = otherwise
+                                .strip_prefix("@")
+                                .map(|f| RawKeyword::FnIntoClosure { fn_name: f.into() });
+                            include
+                                .or(pragma)
+                                .or(fn_into_closure)
+                                .ok_or(SttError::UnknownKeyword(otherwise.to_string()))?
                         }
                     };
                     self.push_token(&mut out, Keyword(kw));


### PR DESCRIPTION
With `(@<fn name>)` it's possible to create a closure with the code from function `<fn name>`

Builtin functions can't be made into closures
Closes #1

- **transform FnDef + name -> Result<Closure>**
- **better creation of closure args struct**
- **token: revamp keywords with arguments, tokenize (@) keyword**
- **lib,parse: parse @ keyword (+ lib def of @ keyword, that should have been commited earlier)**
- **runtime: impl @ keyword, use MissingUserFunction error to specify builtin functions can't be made into closures**
- **examples/closure: test @ keyword and join closures**
