### PR TITLE
Closures capture parent function args

### DIFF
--- a/examples/closure.stt
+++ b/examples/closure.stt
@@ -1,18 +1,18 @@
-#! ./target/debug/stt
+#! /target/debug/stt
 (pragma set manual-array)
 (pragma set debug)
 (include stdlib)
 
 (fn) [ cl-b cl-a ] cl$join {
-	[ cl-a cl-b x ] {
+	[ x ] {
 		cl-b cl-a x @ @
-	} cl-a @ cl-b @
+	}
 }
 
 (fn) [ cl-a cl-b ] cl$join' {
-	[ cl-a cl-b x ] {
+	[ x ] {
 		cl-b cl-a x @ @
-	} cl-a @ cl-b @
+	}
 }
 
 (fn) [a] double { a 2 * }
@@ -24,4 +24,3 @@
 (@double) (@add-one) (@double) cl$join' cl$join' 4 @ prt
 
 
-"uwu %g" %% prt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub enum SttError {
         "Closure's arguments ({closure_args:?})'s parent function values are beeing reset with {parent_args:?}"
     )]
     DEVResettingParentValuesForClosure {
-        closure_args: ClosurePartialArgs,
+        closure_args: Box<ClosurePartialArgs>,
         parent_args: HashMap<FnName, FnArg>,
     },
     #[error(
@@ -97,9 +97,9 @@ pub enum SttError {
         removed
     )]
     DEVOverwrittenClosure {
-        closure_args: ClosurePartialArgs,
+        closure_args: Box<ClosurePartialArgs>,
         index: usize,
-        removed: Value,
+        removed: Box<Value>,
     },
     #[error(
         "Can't make function ({fn_name}) that takes no arguments into closure, since that would never be executed"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,6 @@ pub enum SttError {
     NoSuchVariable(String),
     #[error("Missing char")]
     MissingChar,
-    #[error(transparent)]
-    ParseIntError(#[from] std::num::ParseIntError),
     #[error("TODO")]
     TodoErr,
     #[error("Not enough arguments to execute {name}, got {got:?} needs {needs:?}")]
@@ -89,17 +87,6 @@ pub enum SttError {
     DEVResettingParentValuesForClosure {
         closure_args: Box<ClosurePartialArgs>,
         parent_args: HashMap<FnName, FnArg>,
-    },
-    #[error(
-        "Closure's arguments ({:?}) have been overwritten at [{}] previous value was {:?}",
-        closure_args,
-        index,
-        removed
-    )]
-    DEVOverwrittenClosure {
-        closure_args: Box<ClosurePartialArgs>,
-        index: usize,
-        removed: Box<Value>,
     },
     #[error(
         "Can't make function ({fn_name}) that takes no arguments into closure, since that would never be executed"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -104,6 +104,19 @@ impl Context {
             ExprCont::Keyword(kw) => {
                 return self.execute_kw(kw, source);
             }
+            ExprCont::Immediate(Value::Closure(cl)) => {
+                let cl = cl.clone();
+                if let Some(args) = &self.args {
+                    cl.request_args
+                        .parent_args
+                        .set(args.clone())
+                        .map_err(|old| SttError::DEVResettingParentValuesForClosure {
+                            closure_args: cl.request_args.clone(),
+                            parent_args: old,
+                        })?;
+                }
+                self.stack.push(Value::Closure(cl))
+            }
             ExprCont::Immediate(v) => self.stack.push(v.clone()),
             ExprCont::IncludedCode(Code { source, exprs }) => {
                 self.execute_code(exprs, source)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -111,7 +111,7 @@ impl Context {
                         .parent_args
                         .set(args.clone())
                         .map_err(|old| SttError::DEVResettingParentValuesForClosure {
-                            closure_args: cl.request_args.clone(),
+                            closure_args: Box::new(cl.request_args.clone()),
                             parent_args: old,
                         })?;
                 }


### PR DESCRIPTION
Closes #21

- **runtime: Add parent args to closure instance during immediate cretions**
- **Clippy: SttError was too big, Boxed value and ClosurePartialArgs**
- **Removed unused errors: ParseIntError and DEVOverwrittenClosure from SttError**
