### PR TITLE
Tests, docs and better api

### DIFF
--- a/examples/test.stt
+++ b/examples/test.stt
@@ -1,4 +1,3 @@
-(pragma set debug)
 (include stdlib)
 
 (while) { true } {

--- a/examples/test.stt
+++ b/examples/test.stt
@@ -1,6 +1,1 @@
-(include stdlib)
-
-(while) { true } {
-	"hi" print
-	(break)
-}
+"hello" print

--- a/src/api.rs
+++ b/src/api.rs
@@ -88,7 +88,7 @@ pub fn execute_raw_code(code: Code) -> Result<runtime::Context> {
 fn read_file(file_path: impl AsRef<Path>) -> Result<String> {
     match std::fs::read_to_string(file_path.as_ref()) {
         Ok(cont) => Ok(cont),
-        Err(_) => Err(SttError::CantReadFile(file_path.as_ref().to_path_buf()))
+        Err(_) => Err(SttError::CantReadFile(file_path.as_ref().to_path_buf())),
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,49 @@
+//! # This module exposes the steps of the pipeline for file execution
+//! The steps are:
+//! 1. Parsing and preprocessing the file into tokens, avaliable with [get_tokens]
+//! 2. Pre-processing the file, also avaliable with [get_tokens]
+//! 3. Parsing the tokens into code, avaliable with [get_project_code]
+//! 4. Executing the code, avaliable with [execute_file]
+//!
+//! Each step executes the previous one aswell to forbid jump pipeline steps
+//!
+
 use crate::*;
 
-// step token.rs
-pub fn get_raw_tokens(file_path: &Path) -> Result<TokenBlock> {
+/// # Get tokens by filepath
+/// ```rust
+/// let tokens = stt::api::get_tokens("examples/test.stt");
+/// eprintln!("{:?}", tokens);
+/// ```
+pub fn get_tokens(path: impl AsRef<Path>) -> Result<TokenBlock> {
+    let file_path = PathBuf::from(path.as_ref());
+    let tokens = get_raw_tokens(&file_path)?;
+    preproc_tokens(tokens, &file_path)
+}
+
+/// # Parse tokens into code
+/// ```rust
+/// let code = stt::api::get_project_code("examples/test.stt");
+/// eprintln!("{:?}", code);
+/// ```
+pub fn get_project_code(path: impl AsRef<Path>) -> Result<Code> {
+    let TokenBlock { tokens, source } = get_tokens(path)?;
+    let mut parser = parse::Context::new(tokens);
+    let exprs = parser.parse_block()?;
+    Ok(Code { exprs, source })
+}
+
+/// # Execute code
+/// ```rust
+/// stt::api::execute_file("examples/test.stt");
+/// ```
+pub fn execute_file(path: impl AsRef<Path>) -> Result<()> {
+    let expr_block = get_project_code(path)?;
+    execute_code(expr_block)
+}
+
+// steps for token.rs:
+fn get_raw_tokens(file_path: &Path) -> Result<TokenBlock> {
     let Ok(cont) = std::fs::read_to_string(file_path) else {
         return Err(SttError::CantReadFile(file_path.to_path_buf()));
     };
@@ -12,8 +54,17 @@ pub fn get_raw_tokens(file_path: &Path) -> Result<TokenBlock> {
     })
 }
 
-// step preproc.rs
-pub fn preproc_tokens(
+pub(crate) fn get_tokens_with_procvars(
+    path: impl AsRef<Path>,
+    proc_vars: &mut HashSet<String>,
+) -> Result<TokenBlock> {
+    let file_path = PathBuf::from(path.as_ref());
+    let tokens = get_raw_tokens(&file_path)?;
+    preproc_tokens_with_vars(tokens, &file_path, proc_vars)
+}
+
+// steps for preproc.rs:
+fn preproc_tokens(
     TokenBlock { tokens, source }: TokenBlock,
     file_path: &Path,
 ) -> Result<TokenBlock> {
@@ -23,7 +74,7 @@ pub fn preproc_tokens(
     Ok(TokenBlock { tokens, source })
 }
 
-pub fn preproc_tokens_with_vars(
+fn preproc_tokens_with_vars(
     TokenBlock { tokens, source }: TokenBlock,
     file_path: &Path,
     vars: &mut HashSet<String>,
@@ -34,43 +85,9 @@ pub fn preproc_tokens_with_vars(
     Ok(TokenBlock { tokens, source })
 }
 
-// step parse.rs
-pub fn parse_tokens(TokenBlock { tokens, source }: TokenBlock) -> Result<Code> {
-    let mut parser = parse::Context::new(tokens);
-    let exprs = parser.parse_block()?;
-    Ok(Code { exprs, source })
-}
-
-pub fn execute_code(code: Code) -> Result<()> {
+// step for runtime:
+fn execute_code(code: Code) -> Result<()> {
     let mut executioner = runtime::Context::new();
     executioner.execute_code(&code.exprs, &code.source)?;
     Ok(())
-}
-
-// abstract
-pub fn get_tokens(path: impl AsRef<Path>) -> Result<TokenBlock> {
-    let file_path = PathBuf::from(path.as_ref());
-    let tokens = get_raw_tokens(&file_path)?;
-    preproc_tokens(tokens, &file_path)
-}
-
-pub fn get_tokens_with_procvars(
-    path: impl AsRef<Path>,
-    proc_vars: &mut HashSet<String>,
-) -> Result<TokenBlock> {
-    let file_path = PathBuf::from(path.as_ref());
-    let tokens = get_raw_tokens(&file_path)?;
-    preproc_tokens_with_vars(tokens, &file_path, proc_vars)
-}
-
-pub fn get_project_code(path: impl AsRef<Path>) -> Result<Code> {
-    let TokenBlock { tokens, source } = get_tokens(path)?;
-    let mut parser = parse::Context::new(tokens);
-    let exprs = parser.parse_block()?;
-    Ok(Code { exprs, source })
-}
-
-pub fn execute_file(path: impl AsRef<Path>) -> Result<()> {
-    let expr_block = get_project_code(path)?;
-    execute_code(expr_block)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ mod runtime;
 mod token;
 pub use api::*;
 
+#[cfg(test)]
+mod tests;
+
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -271,7 +274,7 @@ impl FnName {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 enum FnScope {
     Global,   // read and writes to upper-scoped variables
     Local,    // reads upper-scoped variables
@@ -503,7 +506,7 @@ enum ControlFlow {
     Return,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum RawKeyword {
     BubbleError,
     Return,
@@ -516,13 +519,13 @@ enum RawKeyword {
     Break,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct Token {
     cont: TokenCont,
     span: Range<usize>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum TokenCont {
     Ident(String),
     Str(String),
@@ -534,7 +537,7 @@ enum TokenCont {
     EndOfBlock,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TokenBlock {
     source: PathBuf,
     tokens: Vec<Token>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-mod api;
+pub mod api;
 mod parse;
 mod preproc;
 mod runtime;
 mod token;
-pub use api::*;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,9 +631,12 @@ pub struct TokenBlock {
 
 impl TokenBlock {
     pub fn token_count(&self) -> usize {
-        self.tokens.len() - (if self.last_is_eof() {1} else {0})
+        self.tokens.len() - (if self.last_is_eof() { 1 } else { 0 })
     }
     pub fn last_is_eof(&self) -> bool {
-        self.tokens.last().map(|e|matches!(e.cont, TokenCont::EndOfBlock)).unwrap_or(false)
+        self.tokens
+            .last()
+            .map(|e| matches!(e.cont, TokenCont::EndOfBlock))
+            .unwrap_or(false)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use stt::*;
+use stt::{Result, api::*};
 
 #[derive(PartialEq)]
 enum SttMode {

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -54,9 +54,9 @@ impl<'p> Context<'p> {
                         .ok()
                         .ok_or(SttError::CantReadFile(include_path.clone()))?;
                     let included_tokens = if metadata.is_dir() {
-                        get_tokens_with_procvars(include_path.join("stt.stt"), proc_vars)
+                        api::get_tokens_with_procvars(include_path.join("stt.stt"), proc_vars)
                     } else {
-                        get_tokens_with_procvars(include_path, proc_vars)
+                        api::get_tokens_with_procvars(include_path, proc_vars)
                     }?;
                     let included_tokens = TokenCont::IncludedBlock(included_tokens);
                     let included_tokens = Token {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,7 +4,7 @@ mod stack;
 use stack::*;
 use std::boxed::Box;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Context {
     vars: HashMap<String, Value>,
     fns: HashMap<FnName, FnDef>,
@@ -20,6 +20,10 @@ impl Context {
             stack: Stack::new(),
             args: None,
         }
+    }
+
+    pub fn get_stack(&self) -> &[Value] {
+        &self.stack.0
     }
 
     fn frame_fn(
@@ -65,7 +69,17 @@ impl Context {
         }
     }
 
-    pub fn execute_code(&mut self, code: &[Expr], source: &Path) -> Result<ControlFlow> {
+    pub fn execute_entire_code(&mut self, Code { source, exprs }: &Code) -> Result<ControlFlow> {
+        for expr in exprs {
+            match self.execute_expr(expr, &source)? {
+                ControlFlow::Continue => {}
+                c => return Ok(c),
+            }
+        }
+        Ok(ControlFlow::Continue)
+    }
+
+    fn execute_code(&mut self, code: &[Expr], source: &Path) -> Result<ControlFlow> {
         for expr in code {
             match self.execute_expr(expr, source)? {
                 ControlFlow::Continue => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,27 @@
+use crate::*;
+mod token;
+
+trait StrVecIntoStringVec {
+    fn into_strings(self) -> Vec<String>;
+}
+
+impl StrVecIntoStringVec for Vec<&str> {
+    fn into_strings(self) -> Vec<String> {
+        self.into_iter().map(String::from).collect()
+    }
+}
+
+// like assert_eq but shows `got` and `expected`
+macro_rules! test_eq {
+    (got: $got:expr, expected: $expected:expr) => {{
+        if $got != $expected {
+            panic!(
+                r#"assertion failed: `got == expected`
+     got: `{:?}`,
+expected: `{:?}`"#,
+                $got, $expected
+            )
+        }
+    }};
+}
+pub(self) use test_eq;

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -48,7 +48,7 @@ fn read_tokens() {
         let wanted = expected.get(index);
         test_eq!(got: got, expected: wanted);
         if let Some(t) = got {
-            println!("text: {}", text[t.span.clone()].to_string());
+            eprintln!("text: {}", text[t.span.clone()].to_string());
         }
     }
 

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,0 +1,56 @@
+use super::*;
+macro_rules! mkt {
+    ($from:literal .. $to:literal $cont:expr) => {
+        Token {
+            span: $from..$to,
+            cont: $cont,
+        }
+    };
+}
+
+#[test]
+fn read_tokens() {
+    let text = "
+(fn) [ a b c ] fn-name {
+    a b c + +
+}
+1 2 3 fn-name
+";
+    let mut ctx = crate::token::Context::new(text);
+    let block = ctx.tokenize_block();
+    assert!(block.is_ok());
+    let block = block.unwrap();
+    use TokenCont as C;
+
+    let expected: Vec<Token> = vec![
+        mkt!(1..5(C::Keyword(RawKeyword::Fn(FnScope::Local)))),
+        mkt!(6..15(C::FnArgs(vec!["a", "b", "c"].into_strings()))),
+        mkt!(16..24(C::Ident("fn-name".to_string()))),
+        mkt!(
+            24..41(C::Block(vec![
+                mkt!(29..32(C::Ident("a".to_string()))),
+                mkt!(32..34(C::Ident("b".to_string()))),
+                mkt!(34..36(C::Ident("c".to_string()))),
+                mkt!(36..38(C::Ident("+".to_string()))),
+                mkt!(38..40(C::Ident("+".to_string()))),
+                mkt!(41..41(C::EndOfBlock)),
+            ]))
+        ),
+        mkt!(42..44(C::Number(1))),
+        mkt!(44..46(C::Number(2))),
+        mkt!(46..48(C::Number(3))),
+        mkt!(48..56(C::Ident("fn-name".to_string()))),
+        mkt!(56..56(C::EndOfBlock)),
+    ];
+
+    for index in 0..block.len() {
+        let got = block.get(index);
+        let wanted = expected.get(index);
+        test_eq!(got: got, expected: wanted);
+        if let Some(t) = got {
+            println!("text: {}", text[t.span.clone()].to_string());
+        }
+    }
+
+    test_eq!(got: block.len(), expected: expected.len());
+}


### PR DESCRIPTION
Closes #28
Closes #29
Closes #45

- **add tests module + usefull functions + test for tokenizer**
- **examples/test: make example smaller by removing stdlib import**
- **api: add doc comments and have fewer public functions**
- **lib: remove pub use api::\* update users of api:: functions**
- **tests/token: printing to stderr is better than stdout for tests**
- **Better api for direct usage (instead of just file) and access to runtime::Context**
