### PR TITLE
Tokenize last token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,12 @@ pub enum StckError {
     UnknownType(String),
     #[error("Unexpected end of file while building token {0:?}")]
     UnexpectedEOF(token::State),
+    #[error("Tokenizer: No impl for {0:?} with {1:?}")]
+    CantTokenizerChar(token::State, char),
+    #[error("Can only user param list or '*' as function arguments, not {0}")]
+    WrongParamList(String),
+    #[error("Parser: State {0:?} doesn't accept token {1:?}")]
+    CantParseToken(parse::State, TokenCont)
 }
 
 #[derive(Clone, Debug)]
@@ -737,7 +743,7 @@ impl From<Closure> for Value {
 }
 
 #[derive(Clone, Debug)]
-struct CondBranch {
+pub struct CondBranch {
     check: Vec<Expr>,
     code: Vec<Expr>,
 }
@@ -771,7 +777,7 @@ enum KeywordKind {
 }
 
 #[derive(Clone, Debug)]
-struct SwitchCase {
+pub struct SwitchCase {
     test: Value,
     code: Vec<Expr>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub enum StckError {
     #[error("Can only user param list or '*' as function arguments, not {0}")]
     WrongParamList(String),
     #[error("Parser: State {0:?} doesn't accept token {1:?}")]
-    CantParseToken(parse::State, TokenCont)
+    CantParseToken(parse::State, Box<TokenCont>),
 }
 
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@ pub enum StckError {
     },
     #[error("Type `{0}` doesn't exist")]
     UnknownType(String),
+    #[error("Unexpected end of file while building token {0:?}")]
+    UnexpectedEOF(token::State),
 }
 
 #[derive(Clone, Debug)]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -178,7 +178,7 @@ impl Context {
                 }
                 (MakeFnArgs(scope), Ident(i)) => match i.as_str() {
                     "*" => MakeFnNameOrOutArgs(scope, crate::FnArgs::AllStack),
-                    _ => return Err(StckError::WrongParamList(i))
+                    _ => return Err(StckError::WrongParamList(i)),
                 },
                 (MakeFnNameOrOutArgs(scope, args), FnArgs(out_args)) => {
                     MakeFnName(scope, args, out_args)
@@ -217,7 +217,7 @@ impl Context {
                 }
 
                 (s, t) => {
-                    return Err(StckError::CantParseToken(s, t));
+                    return Err(StckError::CantParseToken(s, Box::new(t)));
                 }
             }
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,7 +6,7 @@ pub struct Context {
 }
 
 #[derive(Debug)]
-enum State {
+pub enum State {
     Nothing,
 
     MakeIfs(Vec<CondBranch>),
@@ -178,7 +178,7 @@ impl Context {
                 }
                 (MakeFnArgs(scope), Ident(i)) => match i.as_str() {
                     "*" => MakeFnNameOrOutArgs(scope, crate::FnArgs::AllStack),
-                    x => panic!("Can only user param list or '*' as function arguments, not {x}"),
+                    _ => return Err(StckError::WrongParamList(i))
                 },
                 (MakeFnNameOrOutArgs(scope, args), FnArgs(out_args)) => {
                     MakeFnName(scope, args, out_args)
@@ -217,7 +217,7 @@ impl Context {
                 }
 
                 (s, t) => {
-                    panic!("Parser: State {s:?} doesn't accept token {t:?}")
+                    return Err(StckError::CantParseToken(s, t));
                 }
             }
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,7 +7,7 @@ pub struct Context {
 }
 
 #[derive(Debug)]
-enum State {
+pub enum State {
     Nothing,
     OnComment,
     MakeIdent(String),
@@ -289,7 +289,7 @@ impl Context {
                 }
 
                 (s, c) => {
-                    panic!("Tokenizer: No impl for {s:?} with {c:?}");
+                    return Err(StckError::CantTokenizerChar(s, *c));
                 }
             }
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -294,6 +294,17 @@ impl Context {
             }
         }
         if self.at_eof() {
+            match state {
+                Nothing | OnComment => {}
+                MakeIdent(s) => {
+                    self.push_token(&mut out, Ident(s));
+                }
+                MakeNumber(buf) => {
+                    let num = buf.parse()?;
+                    self.push_token(&mut out, Number(num));
+                }
+                s => return Err(StckError::UnexpectedEOF(s)),
+            }
             self.last_token_pos = self.point;
             self.push_token(&mut out, EndOfBlock);
             Ok(out)


### PR DESCRIPTION
Tokenizer could not tokenize the last token if there wasan't a "\n" in the end
Now this closes #43

- **lib,token: add last token of report error**
- **token,parse: turned panics into errors**
