### PR TITLE
Include fixed span and source on error

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -44,7 +44,7 @@ pub fn get_tokens_str(cont: &str, content_name: impl AsRef<Path>) -> Result<Toke
 /// ```
 pub fn get_project_code(path: impl AsRef<Path>) -> Result<Code> {
     let TokenBlock { tokens, source } = get_tokens(path)?;
-    let mut parser = parse::Context::new(tokens);
+    let mut parser = parse::Context::new(tokens, &source);
     let exprs = parser.parse_block()?;
     Ok(Code { exprs, source })
 }
@@ -57,7 +57,7 @@ pub fn get_project_code(path: impl AsRef<Path>) -> Result<Code> {
 /// assert_eq!(code.expr_count(), 2);
 /// ```
 pub fn parse_raw_tokens(TokenBlock { tokens, source }: TokenBlock) -> Result<Code> {
-    let mut parser = parse::Context::new(tokens);
+    let mut parser = parse::Context::new(tokens, &source);
     let exprs = parser.parse_block()?;
     Ok(Code { exprs, source })
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -66,7 +66,7 @@ pub fn parse_raw_tokens(TokenBlock { tokens, source }: TokenBlock) -> Result<Cod
 /// ```rust
 /// stck::api::execute_file("examples/test.stck");
 /// ```
-pub fn execute_file(path: impl AsRef<Path>) -> Result<()> {
+pub fn execute_file(path: impl AsRef<Path>) -> OResult<(), StckErrorCase> {
     let expr_block = get_project_code(path)?;
     execute_code(expr_block)?;
     Ok(())
@@ -81,7 +81,7 @@ pub fn execute_file(path: impl AsRef<Path>) -> Result<()> {
 /// let ctx = stck::api::execute_raw_code(code).unwrap();
 /// assert_eq!(ctx.get_stack()[0], stck::Value::Num(3));
 /// ```
-pub fn execute_raw_code(code: Code) -> Result<runtime::Context> {
+pub fn execute_raw_code(code: Code) -> OResult<runtime::Context, StckErrorCase> {
     execute_code(code)
 }
 
@@ -134,7 +134,7 @@ fn preproc_tokens_with_vars(
 }
 
 // step for runtime:
-fn execute_code(code: Code) -> Result<runtime::Context> {
+fn execute_code(code: Code) -> OResult<runtime::Context, StckErrorCase> {
     let mut executioner = runtime::Context::new();
     executioner.execute_entire_code(&code)?;
     Ok(executioner)

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,4 +1,4 @@
-use stck::{api::*, StckErrorCase};
+use stck::{StckErrorCase, api::*};
 
 #[derive(PartialEq)]
 enum StckMode {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,4 +1,4 @@
-use stck::{Result, api::*};
+use stck::{api::*, StckErrorCase};
 
 #[derive(PartialEq)]
 enum StckMode {
@@ -9,7 +9,7 @@ enum StckMode {
     PrintProccCode,
 }
 
-fn execute(mode: StckMode, file_path: String) -> Result<()> {
+fn execute(mode: StckMode, file_path: String) -> Result<(), StckErrorCase> {
     use StckMode as M;
     match mode {
         M::Normal => {
@@ -53,7 +53,7 @@ fn main() {
         StckMode::Normal
     };
     if let Err(e) = execute(mode, file_path.clone()) {
-        eprintln!("[ERROR] executing {file_path}:\n  {e}");
+        eprintln!("{e}");
         std::process::exit(1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,13 @@ impl StckError {
 
 impl Display for StckErrorCtx {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Error {}:{:?}\n {}", self.source.display(), self.span, self.kind)?;
+        write!(
+            f,
+            "Error {}:{:?}\n {}",
+            self.source.display(),
+            self.span,
+            self.kind
+        )?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ impl FnArgDef {
     }
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub enum FnArgs {
     Args(Vec<FnArgDef>),
@@ -780,12 +781,14 @@ impl From<Closure> for Value {
     }
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct CondBranch {
     check: Vec<Expr>,
     code: Vec<Expr>,
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 enum KeywordKind {
     IntoClosure {
@@ -814,12 +817,14 @@ enum KeywordKind {
     },
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct SwitchCase {
     test: Value,
     code: Vec<Expr>,
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct Expr {
     #[allow(dead_code)]
@@ -827,6 +832,7 @@ pub struct Expr {
     cont: ExprCont,
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 enum ExprCont {
     Immediate(Value),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub enum StckErrorCase {
 pub struct StckErrorCtx {
     pub source: PathBuf,
     pub span: Range<usize>,
-    pub kind: StckError,
+    pub kind: Box<StckError>,
 }
 
 impl StckErrorCtx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,12 +172,13 @@ pub enum StckError {
     UnexpectedEOF(token::State),
     #[error("Tokenizer: No impl for {0:?} with {1:?}")]
     CantTokenizerChar(token::State, char),
-    #[error("Can only user param list or '*' as function arguments, not {0}")]
-    WrongParamList(String),
-    #[error("Parser: State {0:?} doesn't accept token {1:?}")]
-    CantParseToken(parse::State, Box<TokenCont>),
+    #[error("Parser in file {path}: Can only user param list or '*' as function arguments, not {0}", path=_1.display())]
+    WrongParamList(String, PathBuf),
+    #[error("Parser in file {path}: State {0:?} doesn't accept token {1:?}", path=_2.display())]
+    CantParseToken(parse::State, Box<TokenCont>, PathBuf),
 }
 
+#[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct Code {
     source: PathBuf,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -222,7 +222,11 @@ impl<'p> Context<'p> {
                 }
 
                 (s, t) => {
-                    return Err(StckError::CantParseToken(s, Box::new(t), self.source.to_path_buf()));
+                    return Err(StckError::CantParseToken(
+                        s,
+                        Box::new(t),
+                        self.source.to_path_buf(),
+                    ));
                 }
             };
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -116,7 +116,7 @@ impl Context {
             Err(StckErrorCase::Bubble(e)) => Err(StckErrorCtx {
                 source: source.to_path_buf(),
                 span: expr.span.clone(),
-                kind: e,
+                kind: Box::new(e),
             }),
             Err(StckErrorCase::Context(c)) => Err(c),
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -112,9 +112,13 @@ impl Context {
 
     fn execute_expr_wrap(&mut self, expr: &Expr, source: &Path) -> ResultCtx<ControlFlow> {
         match self.execute_expr(expr, source) {
-            Ok(c)=>Ok(c),
-            Err(StckErrorCase::Bubble(e)) => Err(StckErrorCtx { source: source.to_path_buf(), span: expr.span.clone(), kind: e }),
-            Err(StckErrorCase::Context(c)) => Err(c)
+            Ok(c) => Ok(c),
+            Err(StckErrorCase::Bubble(e)) => Err(StckErrorCtx {
+                source: source.to_path_buf(),
+                span: expr.span.clone(),
+                kind: e,
+            }),
+            Err(StckErrorCase::Context(c)) => Err(c),
         }
     }
 
@@ -175,7 +179,9 @@ impl Context {
                 let cmp = self.stack.pop().ok_or(StckError::RTSwitchCaseWithNoValue)?;
                 for case in cases {
                     if case.test == cmp {
-                        return self.execute_code(&case.code, source).map_err(StckErrorCase::from);
+                        return self
+                            .execute_code(&case.code, source)
+                            .map_err(StckErrorCase::from);
                     }
                 }
                 match default {
@@ -186,7 +192,9 @@ impl Context {
             KeywordKind::Ifs { branches } => {
                 for branch in branches {
                     if self.execute_check(&branch.check, source)? {
-                        return self.execute_code(&branch.code, source).map_err(StckErrorCase::from);
+                        return self
+                            .execute_code(&branch.code, source)
+                            .map_err(StckErrorCase::from);
                     }
                 }
                 ControlFlow::Continue
@@ -278,7 +286,8 @@ impl Context {
                             name: name.as_str().to_string(),
                             got: self.stack.0.clone(),
                             needs: user_fn.args.clone().into_needs(),
-                        }.into_case()));
+                        }
+                        .into_case()));
                     }
                 };
                 let arg_map = args
@@ -512,7 +521,9 @@ impl Context {
                     Value::Result(r) => {
                         match *r {
                             Err(error) => {
-                                return Err(StckError::RTUnwrapResultBuiltinFailed { error }.into_case());
+                                return Err(
+                                    StckError::RTUnwrapResultBuiltinFailed { error }.into_case()
+                                );
                             }
                             Ok(o) => self.stack.push_this(o),
                         };
@@ -528,7 +539,8 @@ impl Context {
                             this_arg: "Monad",
                             got: Box::new(e),
                             expected: "Result or Option",
-                        }.into_case());
+                        }
+                        .into_case());
                     }
                 }
             }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -83,6 +83,6 @@ pub(super) fn fmt(cont: &str, stack: &mut Stack) -> Result<String> {
             FmtError::MissingValue(c) => StckError::RTMissingValue(fmt_str, c),
             FmtError::UnknownStringFormat(c) => StckError::RTUnknownStringFormat(fmt_str, c),
             FmtError::WrongVariableForFormat(v, c) => StckError::RTWrongValueType(fmt_str, v, c),
-        }
+        }.into_case()
     })
 }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -83,6 +83,7 @@ pub(super) fn fmt(cont: &str, stack: &mut Stack) -> Result<String> {
             FmtError::MissingValue(c) => StckError::RTMissingValue(fmt_str, c),
             FmtError::UnknownStringFormat(c) => StckError::RTUnknownStringFormat(fmt_str, c),
             FmtError::WrongVariableForFormat(v, c) => StckError::RTWrongValueType(fmt_str, v, c),
-        }.into_case()
+        }
+        .into_case()
     })
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
+mod parse;
 mod runtime;
 mod token;
 mod typing;
-mod parse;
 
 // like assert_eq but shows `got` and `expected`
 macro_rules! test_eq {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 mod runtime;
 mod token;
 mod typing;
+mod parse;
 
 // like assert_eq but shows `got` and `expected`
 macro_rules! test_eq {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,3 @@
-use crate::*;
 mod runtime;
 mod token;
 mod typing;

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+
+use crate::KeywordKind;
+
+use super::*;
+
+#[test]
+fn parse_tokens() -> Result<(), crate::StckErrorCase> {
+    let text_name = "parse_tokens test";
+    let text = "
+(fn) [ typed<num> in_puts ] [ sum<num> ] fn-name {
+    inputs typed 0 - -
+}";
+    let token_block = crate::api::get_tokens_str(text, text_name.to_string())?;
+    let expr = crate::api::parse_raw_tokens(token_block)?;
+    test_eq!(got: expr.source, expected: PathBuf::from(text_name));
+    test_eq!(got: expr.expr_count(), expected: 1);
+    use crate::{Expr, ExprCont::{Keyword, FnCall, Immediate}};
+    let expr_expected: Vec<crate::Expr> = vec![Expr {
+        span: 0..76,
+        cont: Keyword(KeywordKind::FnDef{
+            name: "fn-name".to_string(),
+            scope: crate::FnScope::Local,
+            code: vec![
+                Expr {
+                    span: 50..63,
+                    cont: FnCall("inputs".to_string()),
+                },
+                Expr {
+                    span: 63..69,
+                    cont: FnCall("typed".to_string()),
+                },
+                Expr {
+                    span: 69..71,
+                    cont: Immediate(crate::Value::Num(0)),
+                },
+                Expr {
+                    span: 71..73,
+                    cont: FnCall("-".to_string()),
+                },
+                Expr {
+                    span: 73..75,
+                    cont: FnCall("-".to_string()),
+                },
+            ],
+            args: crate::FnArgs::Args(vec![
+                crate::FnArgDef {
+                    name: "typed".to_string(),
+                    type_check: Some(crate::TypeTester::Num),
+                },
+                crate::FnArgDef {
+                    name: "in_puts".to_string(),
+                    type_check: None,
+                },
+            ]),
+            out_args: Some(vec![crate::FnArgDef {
+                name: "sum".to_string(),
+                type_check: Some(crate::TypeTester::Num),
+            }]),
+        }),
+    }];
+    test_eq!(got: expr.exprs, expected: expr_expected);
+
+    Ok(())
+}

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -15,10 +15,13 @@ fn parse_tokens() -> Result<(), crate::StckErrorCase> {
     let expr = crate::api::parse_raw_tokens(token_block)?;
     test_eq!(got: expr.source, expected: PathBuf::from(text_name));
     test_eq!(got: expr.expr_count(), expected: 1);
-    use crate::{Expr, ExprCont::{Keyword, FnCall, Immediate}};
+    use crate::{
+        Expr,
+        ExprCont::{FnCall, Immediate, Keyword},
+    };
     let expr_expected: Vec<crate::Expr> = vec![Expr {
         span: 0..76,
-        cont: Keyword(KeywordKind::FnDef{
+        cont: Keyword(KeywordKind::FnDef {
             name: "fn-name".to_string(),
             scope: crate::FnScope::Local,
             code: vec![

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -1,9 +1,10 @@
+use crate::{api, Context, RustStckFn, StckErrorCase, Value};
 use super::*;
 
 #[test]
-fn rust_hook() {
-    let tokens = api::get_tokens_str("\"7 3 -\n\" eval\n", "Raw string").unwrap();
-    let code = api::parse_raw_tokens(tokens).unwrap();
+fn rust_hook() -> Result<(), StckErrorCase>{
+    let tokens = api::get_tokens_str("\"7 3 -\n\" eval\n", "Raw string")?;
+    let code = api::parse_raw_tokens(tokens)?;
     let mut runtime = Context::new();
     let hook = RustStckFn::new("eval".to_string(), |ctx, source| {
         let st = ctx.stack.pop_this(Value::get_str).unwrap().unwrap();
@@ -12,8 +13,9 @@ fn rust_hook() {
         ctx.execute_entire_code(&code).unwrap();
     });
     runtime.add_rust_hook(hook);
-    runtime.execute_entire_code(&code).unwrap();
+    runtime.execute_entire_code(&code)?;
     let stack = runtime.get_stack();
     let expected_stack = [Value::Num(4)];
     test_eq!(got: stack, expected: expected_stack);
+    Ok(())
 }

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -1,8 +1,8 @@
-use crate::{api, Context, RustStckFn, StckErrorCase, Value};
 use super::*;
+use crate::{Context, RustStckFn, StckErrorCase, Value, api};
 
 #[test]
-fn rust_hook() -> Result<(), StckErrorCase>{
+fn rust_hook() -> Result<(), StckErrorCase> {
     let tokens = api::get_tokens_str("\"7 3 -\n\" eval\n", "Raw string")?;
     let code = api::parse_raw_tokens(tokens)?;
     let mut runtime = Context::new();

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,3 +1,4 @@
+use crate::*;
 use super::*;
 macro_rules! mkt {
     ($from:literal .. $to:literal $cont:expr) => {

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use super::*;
+use crate::*;
 macro_rules! mkt {
     ($from:literal .. $to:literal $cont:expr) => {
         Token {

--- a/src/tests/typing.rs
+++ b/src/tests/typing.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::*;
 use TypeTester as TT;
 type TR = std::result::Result<(), TypeTester>;
 const T_OK: TR = TR::Ok(());
@@ -6,7 +7,7 @@ const T_ERR: fn(&TT) -> TR = |d| TR::Err(d.clone());
 
 #[test]
 fn test_simple_types() {
-    let closure_sum = Value::Closure(Box::new(super::Closure {
+    let closure_sum = Value::Closure(Box::new(crate::Closure {
         code: vec![],
         request_args: ClosurePartialArgs::new(vec![
             FnArgDef::new("a".to_string(), Some(TT::Num)),


### PR DESCRIPTION
Fixes #24
Closes #40

- **general implementation of source and span on error, still needs more places to replace source/span**
- **parse,lib: fix token's spans on nested code block parsing**
- **lib: derive Eq for some types for testing**
- **api: send source to parser**
- **tests.rs: removed import of crate::\*; now each test module must handle api usage**
- **test/parse: testing for parser**
