### PR TITLE
Closure method to set parent args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,9 @@ pub struct ClosurePartialArgs {
 }
 
 impl ClosurePartialArgs {
+    fn set_parent(&self, args: HashMap<String, FnArg>) -> OResult<(), HashMap<ArgName, FnArg>> {
+        self.parent_args.set(args)
+    }
     pub fn new(mut arg_list: Vec<FnArgDef>) -> Self {
         arg_list.reverse();
         ClosurePartialArgs {
@@ -315,6 +318,12 @@ struct FullClosure {
 }
 
 impl Closure {
+    pub fn set_parent_args(
+        &self,
+        args: HashMap<String, FnArg>,
+    ) -> OResult<(), HashMap<String, FnArg>> {
+        self.request_args.set_parent(args)
+    }
     fn fill(mut self, value: Value) -> Result<ClosureCurry> {
         if let Err(r) = self.request_args.fill(value) {
             return Err(match r {
@@ -383,7 +392,7 @@ enum FnArgsInsCap {
 #[derive(Debug, Default)]
 pub struct Stack(Vec<Value>);
 #[derive(Debug, Clone)]
-struct FnArg(Value);
+pub struct FnArg(pub Value);
 
 impl Stack {
     fn new_with(v: Vec<Value>) -> Self {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -126,18 +126,17 @@ impl Context {
         match &expr.cont {
             ExprCont::FnCall(name) => self.execute_fn(name, source)?,
             ExprCont::Keyword(kw) => {
-                return self.execute_kw(kw, source).map_err(StckErrorCase::from);
+                return self.execute_kw(kw, source);
             }
             ExprCont::Immediate(Value::Closure(cl)) => {
                 let cl = cl.clone();
                 if let Some(args) = &self.args {
-                    cl.request_args
-                        .parent_args
-                        .set(args.clone())
-                        .map_err(|old| StckError::DEVResettingParentValuesForClosure {
+                    cl.set_parent_args(args.clone()).map_err(|old| {
+                        StckError::DEVResettingParentValuesForClosure {
                             closure_args: Box::new(cl.request_args.clone()),
                             parent_args: old,
-                        })?;
+                        }
+                    })?;
                 }
                 self.stack.push(Value::Closure(cl))
             }

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -11,7 +11,7 @@ fn parse_tokens() -> Result<(), crate::StckErrorCase> {
 (fn) [ typed<num> in_puts ] [ sum<num> ] fn-name {
     inputs typed 0 - -
 }";
-    let token_block = crate::api::get_tokens_str(text, text_name.to_string())?;
+    let token_block = crate::api::get_tokens_str(text, text_name)?;
     let expr = crate::api::parse_raw_tokens(token_block)?;
     test_eq!(got: expr.source, expected: PathBuf::from(text_name));
     test_eq!(got: expr.expr_count(), expected: 1);

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -1,9 +1,17 @@
 use super::*;
 use crate::{Context, RustStckFn, StckErrorCase, Value, api};
 
+fn execute_string(cont: &str, test_name: &str) -> Result<Context, StckErrorCase> {
+    let tokens = api::get_tokens_str(cont, test_name)?;
+    let code = api::parse_raw_tokens(tokens)?;
+    let mut runtime = Context::new();
+    runtime.execute_entire_code(&code)?;
+    Ok(runtime)
+}
+
 #[test]
 fn rust_hook() -> Result<(), StckErrorCase> {
-    let tokens = api::get_tokens_str("\"7 3 -\n\" eval\n", "Raw string")?;
+    let tokens = api::get_tokens_str("\"7 3 -\n\" eval\n", "test rust hook")?;
     let code = api::parse_raw_tokens(tokens)?;
     let mut runtime = Context::new();
     let hook = RustStckFn::new("eval".to_string(), |ctx, source| {
@@ -19,3 +27,31 @@ fn rust_hook() -> Result<(), StckErrorCase> {
     test_eq!(got: stack, expected: expected_stack);
     Ok(())
 }
+
+#[test]
+fn closure_parent_args() -> Result<(), StckErrorCase> {
+    let ctx = execute_string("
+(fn) [ i<num> ] [ <num> ] double { i 2 * }
+(fn) [ first<fn> seccond<fn> ] [ joint<fn> ] join {
+    [ v ]{ first seccond v @ @ }
+}
+
+(@double) (@double) join 2 @
+
+
+[ a ] {
+    [ b ] {
+        [ _ ] {
+            a b -
+        }
+    }
+}
+
+3 @ 4 @ '_' @
+", "Test nested arguments")?;
+    let stack = ctx.get_stack();
+    let expected_stack = [Value::Num(8), Value::Num(-1)];
+    test_eq!(got: stack, expected: expected_stack);
+    Ok(())
+}
+

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -30,7 +30,8 @@ fn rust_hook() -> Result<(), StckErrorCase> {
 
 #[test]
 fn closure_parent_args() -> Result<(), StckErrorCase> {
-    let ctx = execute_string("
+    let ctx = execute_string(
+        "
 (fn) [ i<num> ] [ <num> ] double { i 2 * }
 (fn) [ first<fn> seccond<fn> ] [ joint<fn> ] join {
     [ v ]{ first seccond v @ @ }
@@ -48,10 +49,11 @@ fn closure_parent_args() -> Result<(), StckErrorCase> {
 }
 
 3 @ 4 @ '_' @
-", "Test nested arguments")?;
+",
+        "Test nested arguments",
+    )?;
     let stack = ctx.get_stack();
     let expected_stack = [Value::Num(8), Value::Num(-1)];
     test_eq!(got: stack, expected: expected_stack);
     Ok(())
 }
-


### PR DESCRIPTION
Fixes #64
Closes #56 (This error doesn't happen)

- **lib: Closure,ClosurePartialArgs: .set_parent_args,.set_parent function to set parent args**
- **runtime: usage Closure's .set_parent_args**
- **clippy**
- **tests/runtime: test closure's and functions' arg capture**
- **cargo fmt**
