### PR TITLE
Return root type on check error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -308,7 +308,7 @@ pub enum RuntimeErrorKind {
     MissingValue(String, char),
     #[error("`%%` ({0}) The provided value, {1:?}, can't be formatted with `{2}`")]
     WrongValueType(String, Value, char),
-    #[error("Expected type: {0} got value {1:?}")]
+    #[error("Expected type: {0} got value {1:?}: {ty}", ty=TypeTester::from(_1.as_ref()))]
     Type(TypeTester, Box<Value>),
     #[error("Expected type: {0} got {1}")]
     TypeType(TypeTester, TypeTester),


### PR DESCRIPTION
Fixes #92
Closes #5

- **types: return macro type on TRC.check, instead of failed type**
- **error: RuntimeErrorKind::WrongValueType now shows value's type like '{value}: {type}'**
