### PR TITLE
Removed 'echo OK' from nix ci

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,4 +13,3 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build
-    - run: nix-shell --run "echo OK"


### PR DESCRIPTION
Closes #102

It forced nix to download bash and other deps nedelessly
