### PR TITLE
Parser now updates source on included files

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -191,3 +191,29 @@ impl Display for ErrorSource {
         Ok(())
     }
 }
+
+impl Display for parse::State {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Nothing => "Making nothing",
+
+            Self::MakeIfs(..) => "Making ifs, awaiting conditional check or end",
+            Self::MakeIfsCode { .. } => "Making ifs, awaiting code block to execute",
+
+            Self::MakeFnArgs(..) => "Making function, awaiting args",
+            Self::MakeFnNameOrOutArgs(..) => "Making function, awaiting name or output args",
+            Self::MakeFnName(..) => "Making function, awaiting name",
+            Self::MakeFnBlock(..) => "MakeWhile function, awaiting code block to execute",
+
+            Self::MakeSwitch(..) =>     "Making switch case, awaiting value to match",
+            Self::MakeSwitchCode(..) => "Making switch case, awaiting code block to execute",
+
+            Self::MakeWhile => "Making while loop, awaiting check code block",
+            Self::MakeWhileCode(..) => "MakeWhile while lop, awaiting code block to execute",
+
+            Self::MakeClosureBlockOrOutArgs(..) => "Making closure, awaiting code block to execute or output args",
+            Self::MakeClosureBlock(..) => "Making closure, awaiting code block to execute"
+        };
+        write!(f, "{s}")
+    }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -205,14 +205,16 @@ impl Display for parse::State {
             Self::MakeFnName(..) => "Making function, awaiting name",
             Self::MakeFnBlock(..) => "MakeWhile function, awaiting code block to execute",
 
-            Self::MakeSwitch(..) =>     "Making switch case, awaiting value to match",
+            Self::MakeSwitch(..) => "Making switch case, awaiting value to match",
             Self::MakeSwitchCode(..) => "Making switch case, awaiting code block to execute",
 
             Self::MakeWhile => "Making while loop, awaiting check code block",
             Self::MakeWhileCode(..) => "MakeWhile while lop, awaiting code block to execute",
 
-            Self::MakeClosureBlockOrOutArgs(..) => "Making closure, awaiting code block to execute or output args",
-            Self::MakeClosureBlock(..) => "Making closure, awaiting code block to execute"
+            Self::MakeClosureBlockOrOutArgs(..) => {
+                "Making closure, awaiting code block to execute or output args"
+            }
+            Self::MakeClosureBlock(..) => "Making closure, awaiting code block to execute",
         };
         write!(f, "{s}")
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! # Error handeling module
 
 use super::*;
+use colored::Colorize;
 use std::collections::BTreeSet;
 use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
 use std::ops::Range;
@@ -263,7 +264,11 @@ pub enum StckError {
     UnexpectedEOF(token::State),
     #[error("Tokenizer: No impl for {0:?} with {1:?}")]
     CantTokenizerChar(token::State, char),
-    #[error("Parser in file {path}: State {0:?} doesn't accept token {1:?}", path=_2.display())]
+    #[error(
+        "Parser in file {path}: State ({_0:?}): {state} doesn't accept token: {1:?}",
+        path=_2.display().to_string().green(),
+        state=_0.to_string().yellow()
+    )]
     CantParseToken(parse::State, Box<TokenCont>, PathBuf),
     #[error("Unknown keyword: {0}")]
     UnknownKeyword(String),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -98,7 +98,7 @@ impl<'p> Context<'p> {
                 }
 
                 (s, IncludedBlock(code)) => {
-                    let mut inner_ctx = Context::new(code.tokens, self.source);
+                    let mut inner_ctx = Context::new(code.tokens, &code.source);
                     let parsed_code = inner_ctx.parse_block_start(cum_span.start)?;
                     push_expr!(E::IncludedCode(Code {
                         line_breaks: code.line_breaks,


### PR DESCRIPTION
Closes #89
- **parse: fix: parse contexts started from IncludedBlock tokens now use block's source**
- **error,display: Better looking error for CantParseToken**
