### PR TITLE
Store lines instead of char span

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "stck"
 path = "src/lib.rs"
 
 [features]
+default = [ "interpreter" ]
 interpreter = [ "dep:clap" ]
 
 [[bin]]

--- a/examples/include.stck
+++ b/examples/include.stck
@@ -1,0 +1,3 @@
+(include included.stck)
+(include included.stck)
+will-panic

--- a/examples/included.stck
+++ b/examples/included.stck
@@ -1,0 +1,5 @@
+"hello\n" print
+
+(fn) [] will-panic {
+	"throw" err !
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,18 +47,10 @@ pub fn get_tokens_str(
 /// eprintln!("{:?}", code);
 /// ```
 pub fn get_project_code(path: impl AsRef<Path>, file_cache: &mut impl FileCacher) -> SResult<Code> {
-    let TokenBlock {
-        tokens,
-        source,
-        line_breaks,
-    } = get_tokens(path, file_cache)?;
+    let TokenBlock { tokens, source } = get_tokens(path, file_cache)?;
     let mut parser = parse::Context::new(tokens, &source);
     let exprs = parser.parse_block()?;
-    Ok(Code {
-        line_breaks,
-        source,
-        exprs,
-    })
+    Ok(Code { source, exprs })
 }
 
 /// # Parse expressions from tokens
@@ -68,20 +60,10 @@ pub fn get_project_code(path: impl AsRef<Path>, file_cache: &mut impl FileCacher
 /// let code = stck::api::parse_raw_tokens(token_block).unwrap();
 /// assert_eq!(code.expr_count(), 2);
 /// ```
-pub fn parse_raw_tokens(
-    TokenBlock {
-        line_breaks,
-        tokens,
-        source,
-    }: TokenBlock,
-) -> SResult<Code> {
+pub fn parse_raw_tokens(TokenBlock { tokens, source }: TokenBlock) -> SResult<Code> {
     let mut parser = parse::Context::new(tokens, &source);
     let exprs = parser.parse_block()?;
-    Ok(Code {
-        line_breaks,
-        source,
-        exprs,
-    })
+    Ok(Code { source, exprs })
 }
 
 /// # Execute code from file
@@ -129,30 +111,18 @@ pub fn get_tokens_with_procvars<S: std::hash::BuildHasher>(
 
 // steps for preproc.rs:
 fn preproc_tokens(
-    TokenBlock {
-        tokens,
-        source,
-        line_breaks,
-    }: TokenBlock,
+    TokenBlock { tokens, source }: TokenBlock,
     file_path: &Path,
     file_cache: &mut impl FileCacher,
 ) -> SResult<TokenBlock> {
     let cwd = PathBuf::from(".");
     let preprocessor = preproc::Context::new(file_path.parent().unwrap_or(cwd.as_path()));
     let tokens = preprocessor.parse_clean(tokens, file_cache)?;
-    Ok(TokenBlock {
-        line_breaks,
-        source,
-        tokens,
-    })
+    Ok(TokenBlock { source, tokens })
 }
 
 fn preproc_tokens_with_vars<S: std::hash::BuildHasher>(
-    TokenBlock {
-        tokens,
-        source,
-        line_breaks,
-    }: TokenBlock,
+    TokenBlock { tokens, source }: TokenBlock,
     file_path: &Path,
     vars: &mut HashSet<String, S>,
     file_cache: &mut impl FileCacher,
@@ -160,11 +130,7 @@ fn preproc_tokens_with_vars<S: std::hash::BuildHasher>(
     let cwd = PathBuf::from(".");
     let preprocessor = preproc::Context::new(file_path.parent().unwrap_or(cwd.as_path()));
     let tokens = preprocessor.parse(tokens, vars, file_cache)?;
-    Ok(TokenBlock {
-        line_breaks,
-        source,
-        tokens,
-    })
+    Ok(TokenBlock { source, tokens })
 }
 
 // step for runtime:

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,8 +18,8 @@ pub trait FileCacher {
         let lines: Vec<&str> = entry
             .as_ref()
             .split('\n')
-            .skip(lines.before - 1)
-            .take(lines.during + 1)
+            .skip(lines.start - 1)
+            .take(lines.delta())
             .collect();
         Ok(lines.join("\n"))
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,7 +19,7 @@ pub trait FileCacher {
             .as_ref()
             .split('\n')
             .skip(lines.start - 1)
-            .take(lines.delta())
+            .take(lines.delta().max(1))
             .collect();
         Ok(lines.join("\n"))
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -167,10 +167,10 @@ impl Display for RuntimeErrorCtx {
 
 impl Display for LineRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.end - self.start <= 1 {
+        if self.delta() == 1 {
             write!(f, "{}", self.start)
         } else {
-            write!(f, "{}:+{}", self.start, self.delta())
+            write!(f, "{}:{:+}", self.start, self.delta())
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -167,10 +167,10 @@ impl Display for RuntimeErrorCtx {
 
 impl Display for LineRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.during <= 1 {
-            write!(f, "{}", self.before)
+        if self.end - self.start <= 1 {
+            write!(f, "{}", self.start)
         } else {
-            write!(f, "{}:+{}", self.before, self.during)
+            write!(f, "{}:+{}", self.start, self.end - self.start)
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -167,7 +167,7 @@ impl Display for RuntimeErrorCtx {
 
 impl Display for LineRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.delta() == 1 {
+        if self.delta() == 0 {
             write!(f, "{}", self.start)
         } else {
             write!(f, "{}:{:+}", self.start, self.delta())

--- a/src/display.rs
+++ b/src/display.rs
@@ -170,7 +170,7 @@ impl Display for LineRange {
         if self.end - self.start <= 1 {
             write!(f, "{}", self.start)
         } else {
-            write!(f, "{}:+{}", self.start, self.end - self.start)
+            write!(f, "{}:+{}", self.start, self.delta())
         }
     }
 }

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -7,25 +7,19 @@ use super::*;
 pub use runtime::Context as RuntimeContext;
 use std::cell::OnceCell;
 use std::collections::HashMap;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct Code {
-    pub(crate) line_breaks: LineSpan,
     pub(crate) source: PathBuf,
     pub(crate) exprs: Vec<Expr>,
 }
 
 impl Code {
     #[must_use]
-    pub fn new(source: PathBuf, exprs: Vec<Expr>, line_breaks: LineSpan) -> Self {
-        Code {
-            line_breaks,
-            source,
-            exprs,
-        }
+    pub fn new(source: PathBuf, exprs: Vec<Expr>) -> Self {
+        Code { source, exprs }
     }
     #[must_use]
     pub fn expr_count(&self) -> usize {
@@ -130,7 +124,7 @@ impl ClosurePartialArgs {
             parent: OnceCell::new(),
         }
     }
-    pub fn parse(arg_list: Vec<FnArgDef>, span: Range<usize>) -> Result<Self, StckError> {
+    pub fn parse(arg_list: Vec<FnArgDef>, span: LineRange) -> Result<Self, StckError> {
         if arg_list.is_empty() {
             Err(StckError::CantInstanceClosureZeroArgs { span })
         } else {
@@ -584,7 +578,7 @@ pub struct SwitchCase {
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct Expr {
-    pub(crate) span: Range<usize>,
+    pub(crate) span: LineRange,
     pub cont: ExprCont,
 }
 
@@ -623,7 +617,7 @@ pub enum RawKeyword {
 #[derive(Debug)]
 pub struct Token {
     pub(crate) cont: TokenCont,
-    pub(crate) span: Range<usize>,
+    pub(crate) span: LineRange,
 }
 
 #[cfg_attr(test, derive(PartialEq))]
@@ -648,7 +642,6 @@ pub enum TokenCont {
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Debug)]
 pub struct TokenBlock {
-    pub(crate) line_breaks: LineSpan,
     pub(crate) source: PathBuf,
     pub(crate) tokens: Vec<Token>,
 }

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -578,7 +578,7 @@ pub struct SwitchCase {
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Clone, Debug)]
 pub struct Expr {
-    pub(crate) span: LineRange,
+    pub span: LineRange,
     pub cont: ExprCont,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@ pub mod prelude;
 
 // Avaliabe internally
 pub(crate) use error::{
-    ErrCtx, ErrorSource, LineRange, LineSpan, RuntimeError, RuntimeErrorCtx, RuntimeErrorKind,
-    StckError,
+    ErrCtx, ErrorSource, LineRange, RuntimeError, RuntimeErrorCtx, RuntimeErrorKind, StckError,
 };
 pub(crate) use internals::*;
 pub(crate) use types::*;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -35,7 +35,7 @@ pub enum State {
 
 impl<'p> Context<'p> {
     pub fn parse_block(&mut self) -> Result<Vec<Expr>, StckError> {
-        self.parse_block_start(0)
+        self.parse_block_start(1)
     }
 
     fn parse_block_start(&mut self, span_start: usize) -> Result<Vec<Expr>, StckError> {
@@ -44,7 +44,7 @@ impl<'p> Context<'p> {
         use TokenCont::*;
         let mut state = Nothing;
         let mut out = vec![];
-        let mut cum_span = LineRange::from_points(span_start, span_start);
+        let mut cum_span = LineRange::from_points(span_start, span_start+1);
 
         while let Some(token) = self.next() {
             let Token { cont, span } = token;
@@ -55,7 +55,7 @@ impl<'p> Context<'p> {
                         cont: $expr,
                         span: cum_span,
                     });
-                    cum_span = LineRange::from_points(span.end, span.end);
+                    cum_span = LineRange::from_points(span.end, span.end+1);
                 };
             }
             state = match (state, cont) {
@@ -99,7 +99,7 @@ impl<'p> Context<'p> {
 
                 (s, IncludedBlock(code)) => {
                     let mut inner_ctx = Context::new(code.tokens, &code.source);
-                    let parsed_code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let parsed_code = inner_ctx.parse_block()?;
                     push_expr!(E::IncludedCode(Code {
                         source: code.source,
                         exprs: parsed_code,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -44,7 +44,7 @@ impl<'p> Context<'p> {
         use TokenCont::*;
         let mut state = Nothing;
         let mut out = vec![];
-        let mut cum_span = LineRange::from_points(span_start, span_start+1);
+        let mut cum_span = LineRange::from_points(span_start, span_start + 1);
 
         while let Some(token) = self.next() {
             let Token { cont, span } = token;
@@ -55,7 +55,7 @@ impl<'p> Context<'p> {
                         cont: $expr,
                         span: cum_span,
                     });
-                    cum_span = LineRange::from_points(span.end, span.end+1);
+                    cum_span = LineRange::from_points(span.end, span.end + 1);
                 };
             }
             state = match (state, cont) {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -35,27 +35,29 @@ pub enum State {
 
 impl<'p> Context<'p> {
     pub fn parse_block(&mut self) -> Result<Vec<Expr>, StckError> {
-        self.parse_block_start(1)
-    }
-
-    fn parse_block_start(&mut self, span_start: usize) -> Result<Vec<Expr>, StckError> {
         use ExprCont as E;
         use State::*;
         use TokenCont::*;
         let mut state = Nothing;
         let mut out = vec![];
-        let mut cum_span = LineRange::from_points(span_start, span_start + 1);
+        let mut restart_span = true;
+        let mut cum_span = LineRange::from_points(0, 0);
 
         while let Some(token) = self.next() {
             let Token { cont, span } = token;
             cum_span.end = span.end;
+            if restart_span {
+                restart_span = false;
+                cum_span.start = span.start;
+            }
+
             macro_rules! push_expr {
                 ($expr:expr) => {
                     out.push(Expr {
                         cont: $expr,
-                        span: cum_span,
+                        span: cum_span.clone(),
                     });
-                    cum_span = LineRange::from_points(span.end, span.end + 1);
+                    restart_span = true;
                 };
             }
             state = match (state, cont) {
@@ -120,7 +122,7 @@ impl<'p> Context<'p> {
                 }
                 (MakeClosureBlock(args, outs), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     let closure = Closure {
                         code,
                         trc: TypeResolutionBuilder::new().into(),
@@ -137,13 +139,13 @@ impl<'p> Context<'p> {
                 (MakeSwitch(cases), Number(v)) => MakeSwitchCode(cases, Value::Num(v)),
                 (MakeSwitchCode(mut cases, test), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     cases.push(SwitchCase { test, code });
                     MakeSwitch(cases)
                 }
                 (MakeSwitch(cases), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     push_expr!(E::Keyword(KeywordKind::Switch {
                         cases,
                         default: Some(code),
@@ -168,7 +170,7 @@ impl<'p> Context<'p> {
                 (Nothing, Keyword(RawKeyword::Ifs)) => MakeIfs(vec![]),
                 (MakeIfs(branches), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let check = inner_ctx.parse_block_start(cum_span.start)?;
+                    let check = inner_ctx.parse_block()?;
                     MakeIfsCode { branches, check }
                 }
                 (
@@ -179,7 +181,7 @@ impl<'p> Context<'p> {
                     Block(code),
                 ) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     branches.push(CondBranch { check, code });
                     MakeIfs(branches)
                 }
@@ -214,7 +216,7 @@ impl<'p> Context<'p> {
                 }
                 (MakeFnBlock(scope, args, name, out_args), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     let fndef = E::Keyword(KeywordKind::FnDef {
                         name,
                         scope,
@@ -229,12 +231,12 @@ impl<'p> Context<'p> {
                 (Nothing, Keyword(RawKeyword::While)) => MakeWhile,
                 (MakeWhile, Block(check)) => {
                     let mut inner_ctx = Context::new(check, self.source);
-                    let check = inner_ctx.parse_block_start(cum_span.start)?;
+                    let check = inner_ctx.parse_block()?;
                     MakeWhileCode(check)
                 }
                 (MakeWhileCode(check), Block(code)) => {
                     let mut inner_ctx = Context::new(code, self.source);
-                    let code = inner_ctx.parse_block_start(cum_span.start)?;
+                    let code = inner_ctx.parse_block()?;
                     push_expr!(E::Keyword(KeywordKind::While { check, code }));
                     Nothing
                 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -44,7 +44,7 @@ impl<'p> Context<'p> {
         use TokenCont::*;
         let mut state = Nothing;
         let mut out = vec![];
-        let mut cum_span = span_start..span_start;
+        let mut cum_span = LineRange::from_points(span_start, span_start);
 
         while let Some(token) = self.next() {
             let Token { cont, span } = token;
@@ -55,7 +55,7 @@ impl<'p> Context<'p> {
                         cont: $expr,
                         span: cum_span,
                     });
-                    cum_span = span.end..span.end;
+                    cum_span = LineRange::from_points(span.end, span.end);
                 };
             }
             state = match (state, cont) {
@@ -101,7 +101,6 @@ impl<'p> Context<'p> {
                     let mut inner_ctx = Context::new(code.tokens, &code.source);
                     let parsed_code = inner_ctx.parse_block_start(cum_span.start)?;
                     push_expr!(E::IncludedCode(Code {
-                        line_breaks: code.line_breaks,
                         source: code.source,
                         exprs: parsed_code,
                     }));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,8 @@
 //! # All imports for basic usage
 
-pub use crate::api::*;
+pub use crate::api::{self, *};
 pub use crate::{
-    error::Error,
-    internals::{Code, RuntimeContext},
+    cache::{self, CacheHelper},
+    error::{self, Error},
+    internals::{self, Code, RuntimeContext},
 };

--- a/src/preproc.rs
+++ b/src/preproc.rs
@@ -2,7 +2,6 @@ use crate::cache::FileCacher;
 use crate::error::Error;
 use crate::*;
 use std::collections::HashSet;
-use std::ops::Range;
 use std::path::Path;
 
 enum ProcChange {
@@ -93,7 +92,7 @@ fn manage_pragma<S: std::hash::BuildHasher>(
     if_stack: &mut Vec<ProcStatus>,
     command: &str,
     proc_vars: &mut HashSet<String, S>,
-    span: Range<usize>,
+    span: LineRange,
 ) -> Result<(), Error> {
     let is_reading = if_stack.last().is_none_or(|s| s.reading);
     let proc_cmd = execute_command(command, proc_vars)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -87,16 +87,9 @@ impl Context {
         }
     }
 
-    pub fn execute_entire_code(
-        &mut self,
-        Code {
-            source,
-            exprs,
-            line_breaks,
-        }: &Code,
-    ) -> CResult<ControlFlow> {
+    pub fn execute_entire_code(&mut self, Code { source, exprs }: &Code) -> CResult<ControlFlow> {
         for expr in exprs {
-            match self.execute_expr(expr, source, line_breaks)? {
+            match self.execute_expr(expr, source)? {
                 ControlFlow::Continue => {}
                 c => return Ok(c),
             }
@@ -104,14 +97,9 @@ impl Context {
         Ok(ControlFlow::Continue)
     }
 
-    fn execute_code(
-        &mut self,
-        code: &[Expr],
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> CResult<ControlFlow> {
+    fn execute_code(&mut self, code: &[Expr], source: &Path) -> CResult<ControlFlow> {
         for expr in code {
-            match self.execute_expr(expr, source, line_breaks)? {
+            match self.execute_expr(expr, source)? {
                 ControlFlow::Continue => {}
                 c => return Ok(c),
             }
@@ -119,15 +107,10 @@ impl Context {
         Ok(ControlFlow::Continue)
     }
 
-    fn execute_check(
-        &mut self,
-        code: &[Expr],
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> SResult<bool> {
+    fn execute_check(&mut self, code: &[Expr], source: &Path) -> SResult<bool> {
         let old_stack_size = self.stack.len();
         for expr in code {
-            self.execute_expr(expr, source, line_breaks)?;
+            self.execute_expr(expr, source)?;
         }
         let new_stack_size = self.stack.len();
         let new_should_stack_size = old_stack_size + 1;
@@ -147,34 +130,21 @@ impl Context {
         }
     }
 
-    fn execute_expr(
-        &mut self,
-        expr: &Expr,
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> CResult<ControlFlow> {
-        match self.execute_expr_internal(expr, source, line_breaks) {
+    fn execute_expr(&mut self, expr: &Expr, source: &Path) -> CResult<ControlFlow> {
+        match self.execute_expr_internal(expr, source) {
             Ok(c) => Ok(c),
-            Err(RuntimeError::RuntimeRaw(e)) => Err(RuntimeErrorCtx::new(
-                ErrCtx::new(source, expr, line_breaks),
-                e,
-            )),
-            Err(RuntimeError::RuntimeCtx(c)) => {
-                Err(c.append_stack(ErrCtx::new(source, expr, line_breaks)))
+            Err(RuntimeError::RuntimeRaw(e)) => {
+                Err(RuntimeErrorCtx::new(ErrCtx::new(source, expr), e))
             }
+            Err(RuntimeError::RuntimeCtx(c)) => Err(c.append_stack(ErrCtx::new(source, expr))),
         }
     }
 
-    fn execute_expr_internal(
-        &mut self,
-        expr: &Expr,
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> SResult<ControlFlow> {
+    fn execute_expr_internal(&mut self, expr: &Expr, source: &Path) -> SResult<ControlFlow> {
         match &expr.cont {
-            ExprCont::FnCall(name) => self.execute_fn(name, source, line_breaks)?,
+            ExprCont::FnCall(name) => self.execute_fn(name, source)?,
             ExprCont::Keyword(kw) => {
-                return self.execute_kw(kw, source, line_breaks);
+                return self.execute_kw(kw, source);
             }
             ExprCont::Immediate(Value::Closure(cl)) => {
                 let cl = cl.clone();
@@ -189,23 +159,14 @@ impl Context {
                 self.stack.push(Value::Closure(cl));
             }
             ExprCont::Immediate(v) => self.stack.push(v.clone()),
-            ExprCont::IncludedCode(Code {
-                source,
-                exprs,
-                line_breaks,
-            }) => {
-                self.execute_code(exprs, source, line_breaks)?;
+            ExprCont::IncludedCode(Code { source, exprs }) => {
+                self.execute_code(exprs, source)?;
             }
         }
         Ok(ControlFlow::Continue)
     }
 
-    fn execute_kw(
-        &mut self,
-        kw: &KeywordKind,
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> SResult<ControlFlow> {
+    fn execute_kw(&mut self, kw: &KeywordKind, source: &Path) -> SResult<ControlFlow> {
         Ok(match kw {
             KeywordKind::DefinedGeneric(trc) => {
                 self.trc.add_generic(trc.clone());
@@ -247,28 +208,28 @@ impl Context {
                 for case in cases {
                     if case.test == cmp {
                         return self
-                            .execute_code(&case.code, source, line_breaks)
+                            .execute_code(&case.code, source)
                             .map_err(error::RuntimeError::from);
                     }
                 }
                 match default {
-                    Some(code) => self.execute_code(code, source, line_breaks)?,
+                    Some(code) => self.execute_code(code, source)?,
                     None => ControlFlow::Continue,
                 }
             }
             KeywordKind::Ifs { branches } => {
                 for branch in branches {
-                    if self.execute_check(&branch.check, source, line_breaks)? {
+                    if self.execute_check(&branch.check, source)? {
                         return self
-                            .execute_code(&branch.code, source, line_breaks)
+                            .execute_code(&branch.code, source)
                             .map_err(error::RuntimeError::from);
                     }
                 }
                 ControlFlow::Continue
             }
             KeywordKind::While { check, code } => {
-                while self.execute_check(check, source, line_breaks)? {
-                    match self.execute_code(code, source, line_breaks)? {
+                while self.execute_check(check, source)? {
+                    match self.execute_code(code, source)? {
                         ControlFlow::Break => break,
                         ControlFlow::Return => return Ok(ControlFlow::Return),
                         ControlFlow::Continue => {}
@@ -298,10 +259,10 @@ impl Context {
         })
     }
 
-    fn execute_fn(&mut self, name: &FnName, source: &Path, line_breaks: &LineSpan) -> SResult<()> {
+    fn execute_fn(&mut self, name: &FnName, source: &Path) -> SResult<()> {
         // builtin fn should handle stack pop and push
         // and are always given precedence
-        match self.try_execute_builtin(name.as_str(), source, line_breaks) {
+        match self.try_execute_builtin(name.as_str(), source) {
             Ok(()) => return Ok(()),
             Err(error::RuntimeError::RuntimeRaw(Rtk::NoSuchBuiltin)) => {}
             Err(e) => return Err(e),
@@ -311,7 +272,7 @@ impl Context {
             // try_get_arg should not pop from the stack and has higher precedence than user-defined funcs.
             // this was done to avoid confusion if an outer-scoped function was used instead of an argument
             self.stack.push(arg);
-        } else if let Some(rets) = self.try_execute_user_fn(name, line_breaks) {
+        } else if let Some(rets) = self.try_execute_user_fn(name) {
             // try_execute_user_fn should handle stack pop
             // and have the lowest precedence, since the traverse the scopes
             self.stack.pushn(rets?);
@@ -326,7 +287,6 @@ impl Context {
         &mut self,
         closure: FullClosure,
         source: &Path,
-        line_breaks: &LineSpan,
     ) -> SResult<Vec<Value>> {
         let mut cl_ctx = Context::frame_closure(
             self.fns.clone(),
@@ -335,7 +295,7 @@ impl Context {
             self.rust_fns.clone(),
             self.trc.clone(),
         );
-        cl_ctx.execute_code(&closure.code, source, line_breaks)?;
+        cl_ctx.execute_code(&closure.code, source)?;
         let output = cl_ctx.take_stack().into_vec();
         // TODO: use TRC instance from closure
         let mut trc: TypeResolutionContext = self.trc.clone().into();
@@ -353,11 +313,7 @@ impl Context {
         Ok(output)
     }
 
-    fn try_execute_user_fn(
-        &mut self,
-        name: &FnName,
-        line_breaks: &LineSpan,
-    ) -> Option<SResult<Vec<Value>>> {
+    fn try_execute_user_fn(&mut self, name: &FnName) -> Option<SResult<Vec<Value>>> {
         let user_fn = self.fns.get(name)?;
         let mut trc: TypeResolutionContext = self.trc.clone().into();
 
@@ -408,7 +364,7 @@ impl Context {
         );
 
         // handle (return) kw and RT errors inside functions
-        if let Err(e) = fn_ctx.execute_code(&user_fn.code, &user_fn.source, line_breaks) {
+        if let Err(e) = fn_ctx.execute_code(&user_fn.code, &user_fn.source) {
             return Some(Err(e.into()));
         }
 
@@ -449,12 +405,7 @@ impl Context {
         Some(())
     }
 
-    fn try_execute_builtin(
-        &mut self,
-        fn_name: &str,
-        source: &Path,
-        line_breaks: &LineSpan,
-    ) -> SResult<()> {
+    fn try_execute_builtin(&mut self, fn_name: &str, source: &Path) -> SResult<()> {
         match fn_name {
             // seq system
             "print" => {
@@ -575,7 +526,7 @@ impl Context {
                         self.stack.push_this(cl);
                     }
                     ClosureCurry::Full(cl) => {
-                        let result = self.try_execute_user_closure(cl, source, line_breaks)?;
+                        let result = self.try_execute_user_closure(cl, source)?;
                         self.stack.pushn(result);
                     }
                 }

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -21,32 +21,10 @@ fn parse_tokens() -> Result<(), crate::error::Error> {
     test_eq!(got: expr.source, expected: PathBuf::from(text_name));
     test_eq!(got: expr.expr_count(), expected: 1);
     let expr_expected: Vec<crate::Expr> = vec![Expr {
-        span: LineRange::from_points(0, 4),
+        span: LineRange::from_points(2, 4),
         cont: Keyword(KeywordKind::FnDef {
             name: "fn-name".to_string(),
             scope: crate::FnScope::Local,
-            code: vec![
-                Expr {
-                    span: LineRange::from_points(2, 2),
-                    cont: FnCall("inputs".to_string()),
-                },
-                Expr {
-                    span: LineRange::from_points(2, 2),
-                    cont: FnCall("typed".to_string()),
-                },
-                Expr {
-                    span: LineRange::from_points(2, 2),
-                    cont: Immediate(crate::Value::Num(0)),
-                },
-                Expr {
-                    span: LineRange::from_points(2, 2),
-                    cont: FnCall("-".to_string()),
-                },
-                Expr {
-                    span: LineRange::from_points(2, 2),
-                    cont: FnCall("-".to_string()),
-                },
-            ],
             args: crate::FnArgs::Args(vec![
                 crate::FnArgDef {
                     name: "typed".to_string(),
@@ -57,6 +35,28 @@ fn parse_tokens() -> Result<(), crate::error::Error> {
                     type_check: None,
                 },
             ]),
+            code: vec![
+                Expr {
+                    span: LineRange::from_points(3, 3),
+                    cont: FnCall("inputs".to_string()),
+                },
+                Expr {
+                    span: LineRange::from_points(3, 3),
+                    cont: FnCall("typed".to_string()),
+                },
+                Expr {
+                    span: LineRange::from_points(3, 3),
+                    cont: Immediate(crate::Value::Num(0)),
+                },
+                Expr {
+                    span: LineRange::from_points(3, 3),
+                    cont: FnCall("-".to_string()),
+                },
+                Expr {
+                    span: LineRange::from_points(3, 3),
+                    cont: FnCall("-".to_string()),
+                },
+            ],
             out_args: Some(vec![crate::FnArgDef {
                 name: "sum".to_string(),
                 type_check: Some(crate::TypeTester::Num),

--- a/src/tests/parse.rs
+++ b/src/tests/parse.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use super::*;
 use crate::KeywordKind;
+use crate::LineRange;
 
 #[test]
 fn parse_tokens() -> Result<(), crate::error::Error> {
@@ -20,29 +21,29 @@ fn parse_tokens() -> Result<(), crate::error::Error> {
     test_eq!(got: expr.source, expected: PathBuf::from(text_name));
     test_eq!(got: expr.expr_count(), expected: 1);
     let expr_expected: Vec<crate::Expr> = vec![Expr {
-        span: 0..76,
+        span: LineRange::from_points(0, 4),
         cont: Keyword(KeywordKind::FnDef {
             name: "fn-name".to_string(),
             scope: crate::FnScope::Local,
             code: vec![
                 Expr {
-                    span: 50..63,
+                    span: LineRange::from_points(2, 2),
                     cont: FnCall("inputs".to_string()),
                 },
                 Expr {
-                    span: 63..69,
+                    span: LineRange::from_points(2, 2),
                     cont: FnCall("typed".to_string()),
                 },
                 Expr {
-                    span: 69..71,
+                    span: LineRange::from_points(2, 2),
                     cont: Immediate(crate::Value::Num(0)),
                 },
                 Expr {
-                    span: 71..73,
+                    span: LineRange::from_points(2, 2),
                     cont: FnCall("-".to_string()),
                 },
                 Expr {
-                    span: 73..75,
+                    span: LineRange::from_points(2, 2),
                     cont: FnCall("-".to_string()),
                 },
             ],

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -3,7 +3,7 @@ use crate::*;
 macro_rules! mkt {
     ($from:literal .. $to:literal $cont:expr) => {
         Token {
-            span: $from..$to,
+            span: LineRange::from_points($from, $to),
             cont: $cont,
         }
     };
@@ -22,9 +22,9 @@ fn read_tokens() -> Result<(), error::Error> {
     let block = ctx.tokenize("read_tokens test".into())?;
 
     let expected = [
-        mkt!(1..5(C::Keyword(RawKeyword::Fn(FnScope::Local)))),
+        mkt!(1..1(C::Keyword(RawKeyword::Fn(FnScope::Local)))),
         mkt!(
-            6..15(C::FnArgs(
+            1..1(C::FnArgs(
                 ["a", "b", "c"]
                     .into_iter()
                     .map(String::from)
@@ -32,31 +32,28 @@ fn read_tokens() -> Result<(), error::Error> {
                     .collect()
             ))
         ),
-        mkt!(16..24(C::Ident("fn-name".to_string()))),
+        mkt!(1..1(C::Ident("fn-name".to_string()))),
         mkt!(
-            24..41(C::Block(vec![
-                mkt!(29..32(C::Ident("a".to_string()))),
-                mkt!(32..34(C::Ident("b".to_string()))),
-                mkt!(34..36(C::Ident("c".to_string()))),
-                mkt!(36..38(C::Ident("+".to_string()))),
-                mkt!(38..40(C::Ident("+".to_string()))),
-                mkt!(41..41(C::EndOfBlock)),
+            2..2(C::Block(vec![
+                mkt!(2..2(C::Ident("a".to_string()))),
+                mkt!(2..2(C::Ident("b".to_string()))),
+                mkt!(2..2(C::Ident("c".to_string()))),
+                mkt!(2..2(C::Ident("+".to_string()))),
+                mkt!(2..2(C::Ident("+".to_string()))),
+                mkt!(2..2(C::EndOfBlock)),
             ]))
         ),
-        mkt!(42..44(C::Number(1))),
-        mkt!(44..46(C::Number(2))),
-        mkt!(46..48(C::Number(3))),
-        mkt!(48..56(C::Ident("fn-name".to_string()))),
-        mkt!(56..56(C::EndOfBlock)),
+        mkt!(3..3(C::Number(1))),
+        mkt!(3..3(C::Number(2))),
+        mkt!(3..3(C::Number(3))),
+        mkt!(3..3(C::Ident("fn-name".to_string()))),
+        mkt!(3..3(C::EndOfBlock)),
     ];
 
     for index in 0..block.token_count() {
         let got = block.get(index);
         let wanted = expected.get(index);
         test_eq!(got: got, expected: wanted);
-        if let Some(t) = got {
-            eprintln!("text: {}", &text[t.span.clone()]);
-        }
     }
 
     test_eq!(got: block.tokens.len(), expected: expected.len());

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -12,8 +12,7 @@ macro_rules! mkt {
 #[test]
 fn read_tokens() -> Result<(), error::Error> {
     use TokenCont as C;
-    let text = "
-(fn) [ a b c ] fn-name {
+    let text = "(fn) [ a b c ] fn-name {
     a b c + +
 }
 1 2 3 fn-name
@@ -34,20 +33,20 @@ fn read_tokens() -> Result<(), error::Error> {
         ),
         mkt!(1..1(C::Ident("fn-name".to_string()))),
         mkt!(
-            2..2(C::Block(vec![
+            1..3(C::Block(vec![
                 mkt!(2..2(C::Ident("a".to_string()))),
                 mkt!(2..2(C::Ident("b".to_string()))),
                 mkt!(2..2(C::Ident("c".to_string()))),
                 mkt!(2..2(C::Ident("+".to_string()))),
                 mkt!(2..2(C::Ident("+".to_string()))),
-                mkt!(2..2(C::EndOfBlock)),
+                mkt!(3..3(C::EndOfBlock)),
             ]))
         ),
-        mkt!(3..3(C::Number(1))),
-        mkt!(3..3(C::Number(2))),
-        mkt!(3..3(C::Number(3))),
-        mkt!(3..3(C::Ident("fn-name".to_string()))),
-        mkt!(3..3(C::EndOfBlock)),
+        mkt!(4..4(C::Number(1))),
+        mkt!(4..4(C::Number(2))),
+        mkt!(4..4(C::Number(3))),
+        mkt!(4..4(C::Ident("fn-name".to_string()))),
+        mkt!(4..4(C::EndOfBlock)),
     ];
 
     for index in 0..block.token_count() {

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -12,8 +12,8 @@ macro_rules! mkt {
 #[test]
 fn read_tokens() -> Result<(), error::Error> {
     use TokenCont as C;
-    let text = "(fn) [ a b c ] fn-name {
-    a b c + +
+    let text = "(fn) [ typed<num> in_puts a ] [ sum<num> ] fn-name {
+    inputs typed a + +
 }
 1 2 3 fn-name
 ";
@@ -23,20 +23,33 @@ fn read_tokens() -> Result<(), error::Error> {
     let expected = [
         mkt!(1..1(C::Keyword(RawKeyword::Fn(FnScope::Local)))),
         mkt!(
-            1..1(C::FnArgs(
-                ["a", "b", "c"]
-                    .into_iter()
-                    .map(String::from)
-                    .map(|s| FnArgDef::new(s, None))
-                    .collect()
-            ))
+            1..1(C::FnArgs(vec![
+                FnArgDef {
+                    name: "typed".to_string(),
+                    type_check: Some(TypeTester::Num)
+                },
+                FnArgDef {
+                    name: "in_puts".to_string(),
+                    type_check: None
+                },
+                FnArgDef {
+                    name: "a".to_string(),
+                    type_check: None
+                }
+            ]))
+        ),
+        mkt!(
+            1..1(C::FnArgs(vec![FnArgDef {
+                name: "sum".to_string(),
+                type_check: Some(TypeTester::Num)
+            },]))
         ),
         mkt!(1..1(C::Ident("fn-name".to_string()))),
         mkt!(
             1..3(C::Block(vec![
+                mkt!(2..2(C::Ident("inputs".to_string()))),
+                mkt!(2..2(C::Ident("typed".to_string()))),
                 mkt!(2..2(C::Ident("a".to_string()))),
-                mkt!(2..2(C::Ident("b".to_string()))),
-                mkt!(2..2(C::Ident("c".to_string()))),
                 mkt!(2..2(C::Ident("+".to_string()))),
                 mkt!(2..2(C::Ident("+".to_string()))),
                 mkt!(3..3(C::EndOfBlock)),

--- a/src/token.rs
+++ b/src/token.rs
@@ -66,7 +66,7 @@ macro_rules! matches {
 impl Context {
     fn push_token(&mut self, out: &mut Vec<Token>, token: TokenCont) {
         self.last_line = self.current_line;
-        let span = LineRange::from_points(self.last_line, self.current_line);
+        let span = LineRange::from_points(self.last_line, self.current_line+1);
         out.push(Token { cont: token, span });
     }
     pub fn tokenize(mut self, source: PathBuf) -> Result<TokenBlock> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,8 +9,8 @@ use crate::{
 type Result<T> = std::result::Result<T, StckError>;
 
 pub struct Context {
+    changed_line: bool,
     current_line: usize,
-    last_line: usize,
     point: usize,
     chars: Vec<char>,
 }
@@ -20,16 +20,17 @@ pub enum State {
     Nothing,
     OnComment,
     MakeIdent(String),
-    MakeString(String),
-    MakeStringEsc(String), // found \ on string
+    MakeString(String, usize),
+    MakeStringEsc(String, usize), // found \ on string
     MakeNumber(String),
-    MakeKeyword(String),
-    MakeFnArgs(Vec<FnArgDef>, String),
+    MakeKeyword(String, usize),
+    MakeFnArgs(Vec<FnArgDef>, String, usize),
     MakeFnArgType {
         args: Vec<FnArgDef>,
         arg_name: String,
         type_buf: String,
         tag_count: usize,
+        line_start: usize,
     },
     MakeChar,
     MakeCharEnd(char),
@@ -65,8 +66,11 @@ macro_rules! matches {
 
 impl Context {
     fn push_token(&mut self, out: &mut Vec<Token>, token: TokenCont) {
-        self.last_line = self.current_line;
-        let span = LineRange::from_points(self.last_line, self.current_line+1);
+        let span = LineRange::from_points(self.current_line, self.current_line);
+        out.push(Token { cont: token, span });
+    }
+    fn push_multiline_token(&mut self, out: &mut Vec<Token>, token: TokenCont, line_start: usize) {
+        let span = LineRange::from_points(line_start, self.current_line);
         out.push(Token { cont: token, span });
     }
     pub fn tokenize(mut self, source: PathBuf) -> Result<TokenBlock> {
@@ -84,25 +88,20 @@ impl Context {
         while let Some(ch) = self.next() {
             state = match (state, ch) {
                 (Nothing, '}') => {
-                    self.last_line = self.current_line;
                     self.push_token(&mut out, EndOfBlock);
                     return Ok(out);
                 }
                 (Nothing, '{') => {
-                    // keep start of block's span = to where { is
-                    // but use end of block span = to where } is
-                    let last_token_line = self.last_line;
+                    let block_start = self.current_line;
                     let block = self.tokenize_block()?;
-                    // whyyyyy??
-                    self.last_line = last_token_line;
-                    self.push_token(&mut out, Block(block));
+                    self.push_multiline_token(&mut out, Block(block), block_start);
                     Nothing
                 }
                 (Nothing, c @ matches!(start_ident)) => MakeIdent(String::from(*c)),
-                (Nothing, '"') => MakeString(String::new()),
+                (Nothing, '"') => MakeString(String::new(), self.current_line),
                 (Nothing, c @ matches!(digit)) => MakeNumber(String::from(*c)),
-                (Nothing, '(') => MakeKeyword(String::new()),
-                (Nothing, '[') => MakeFnArgs(Vec::new(), String::new()),
+                (Nothing, '(') => MakeKeyword(String::new(), self.current_line),
+                (Nothing, '[') => MakeFnArgs(Vec::new(), String::new(), self.current_line),
                 (Nothing, '\'') => MakeChar,
                 (MakeChar, c) => MakeCharEnd(*c),
                 (MakeCharEnd('\\'), c @ ('\\' | '\'')) => MakeCharEndEsc(*c),
@@ -130,22 +129,22 @@ impl Context {
                     Nothing
                 }
 
-                (MakeString(buf), '"') => {
-                    self.push_token(&mut out, Str(buf));
+                (MakeString(buf, line_start), '"') => {
+                    self.push_multiline_token(&mut out, Str(buf), line_start);
                     Nothing
                 }
-                (MakeString(buf), '\\') => MakeStringEsc(buf),
-                (MakeString(mut buf), c) => {
+                (MakeString(buf, line_start), '\\') => MakeStringEsc(buf, line_start),
+                (MakeString(mut buf, line_start), c) => {
                     buf.push(*c);
-                    MakeString(buf)
+                    MakeString(buf, line_start)
                 }
-                (MakeStringEsc(mut buf), '\\') => {
+                (MakeStringEsc(mut buf, line_start), '\\') => {
                     buf.push('\\');
-                    MakeString(buf)
+                    MakeString(buf, line_start)
                 }
-                (MakeStringEsc(mut buf), 'n') => {
+                (MakeStringEsc(mut buf, line_start), 'n') => {
                     buf.push('\n');
-                    MakeString(buf)
+                    MakeString(buf, line_start)
                 }
 
                 (MakeNumber(mut buf), c @ matches!(digit)) => {
@@ -164,7 +163,7 @@ impl Context {
                     Nothing
                 }
 
-                (MakeKeyword(buf), ')') => {
+                (MakeKeyword(buf, line_start), ')') => {
                     let kw = match buf.as_str().trim() {
                         "!" => RawKeyword::BubbleError,
                         "fn" => RawKeyword::Fn(FnScope::Local),
@@ -201,25 +200,26 @@ impl Context {
                                 .ok_or(StckError::UnknownKeyword(otherwise.to_string()))?
                         }
                     };
-                    self.push_token(&mut out, Keyword(kw));
+                    self.push_multiline_token(&mut out, Keyword(kw), line_start);
                     Nothing
                 }
-                (MakeKeyword(mut buf), c) => {
+                (MakeKeyword(mut buf, line_start), c) => {
                     buf.push(*c);
-                    MakeKeyword(buf)
+                    MakeKeyword(buf, line_start)
                 }
 
-                (MakeFnArgs(mut xs, buf), matches!(space)) => {
+                (MakeFnArgs(mut xs, buf, line_start), matches!(space)) => {
                     if !buf.is_empty() {
                         xs.push(FnArgDef::new_untyped(buf));
                     }
-                    MakeFnArgs(xs, String::new())
+                    MakeFnArgs(xs, String::new(), line_start)
                 }
-                (MakeFnArgs(args, arg_name), '<') => MakeFnArgType {
+                (MakeFnArgs(args, arg_name, line_start), '<') => MakeFnArgType {
                     args,
                     arg_name,
                     type_buf: String::new(),
                     tag_count: 0,
+                    line_start,
                 },
                 (
                     MakeFnArgType {
@@ -227,6 +227,7 @@ impl Context {
                         arg_name,
                         mut type_buf,
                         tag_count,
+                        line_start,
                     },
                     c @ matches!(arg_type),
                 ) => {
@@ -236,6 +237,7 @@ impl Context {
                         arg_name,
                         type_buf,
                         tag_count,
+                        line_start,
                     }
                 }
                 (
@@ -244,6 +246,7 @@ impl Context {
                         arg_name,
                         mut type_buf,
                         tag_count,
+                        line_start,
                     },
                     c @ '<',
                 ) => {
@@ -253,6 +256,7 @@ impl Context {
                         arg_name,
                         type_buf,
                         tag_count: tag_count + 1,
+                        line_start,
                     }
                 }
                 (
@@ -261,12 +265,13 @@ impl Context {
                         arg_name,
                         type_buf,
                         tag_count: 0,
+                        line_start,
                     },
                     '>',
                 ) => {
                     let x = FnArgDef::new_typed(arg_name, type_buf.trim().parse()?);
                     args.push(x);
-                    MakeFnArgs(args, String::new())
+                    MakeFnArgs(args, String::new(), line_start)
                 }
                 (
                     MakeFnArgType {
@@ -274,6 +279,7 @@ impl Context {
                         arg_name,
                         mut type_buf,
                         tag_count,
+                        line_start,
                     },
                     c @ '>',
                 ) => {
@@ -283,24 +289,24 @@ impl Context {
                         arg_name,
                         type_buf,
                         tag_count: tag_count - 1,
+                        line_start,
                     }
                 }
-                (MakeFnArgs(xs, mut buf), c @ matches!(arg_ident)) => {
+                (MakeFnArgs(xs, mut buf, line_start), c @ matches!(arg_ident)) => {
                     buf.push(*c);
-                    MakeFnArgs(xs, buf)
+                    MakeFnArgs(xs, buf, line_start)
                 }
-                (MakeFnArgs(mut xs, buf), ']') => {
+                (MakeFnArgs(mut xs, buf, line_start), ']') => {
                     if !buf.is_empty() {
                         xs.push(FnArgDef::new_untyped(buf));
                     }
-                    self.push_token(&mut out, FnArgs(xs));
+                    self.push_multiline_token(&mut out, FnArgs(xs), line_start);
                     Nothing
                 }
 
                 (Nothing, '#') => OnComment,
                 (OnComment, '\n') => Nothing,
                 (OnComment, _) => OnComment,
-
                 (Nothing, matches!(space)) => Nothing,
 
                 (s, c) => {
@@ -333,8 +339,12 @@ impl Context {
 
     fn next(&mut self) -> Option<&char> {
         let ch = self.chars.get(self.point)?;
-        if ch == &'\n' {
+        if self.changed_line {
             self.current_line += 1;
+            self.changed_line = false;
+        }
+        if ch == &'\n' {
+            self.changed_line = true;
         }
         self.point += 1;
         Some(ch)
@@ -348,9 +358,9 @@ impl Context {
     pub fn new(code: &str) -> Self {
         let chars: Vec<char> = code.chars().collect();
         Self {
+            changed_line: false,
             point: 0,
             chars,
-            last_line: 1,
             current_line: 1,
         }
     }

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -1,9 +1,7 @@
 use clap::{Parser, ValueEnum};
-use stck::cache::{CacheHelper, FileCacher};
-use std::path::PathBuf;
-
 use colored::Colorize;
 use stck::prelude::*;
+use std::path::PathBuf;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 enum StckMode {
@@ -40,7 +38,7 @@ fn print_code(code: &stck::internals::Code, import_stack: usize) {
 fn execute(
     mode: StckMode,
     file_path: PathBuf,
-    file_cache: &mut impl FileCacher,
+    file_cache: &mut impl cache::FileCacher,
 ) -> Result<(), Error> {
     use StckMode as M;
     match mode {
@@ -78,7 +76,7 @@ fn main() {
     let mut file_cacher = CacheHelper::new();
     if let Err(e) = execute(mode, file, &mut file_cacher) {
         eprintln!("{e}");
-        if let stck::error::Error::RuntimeError(stck::error::RuntimeError::RuntimeCtx(e)) = e {
+        if let Error::RuntimeError(error::RuntimeError::RuntimeCtx(e)) = e {
             let spans: stck::error::ErrorSpans = e.into();
             let sources = spans.try_into_sources(&mut file_cacher).unwrap();
             for source in sources {

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, ValueEnum};
 use stck::cache::{CacheHelper, FileCacher};
-use std::fmt::Display;
 use std::path::PathBuf;
 
 use colored::Colorize;
@@ -65,7 +64,7 @@ fn execute(
 struct Cli {
     file: PathBuf,
 
-    #[arg(short, long, value_name = "Mode", default_value_t=StckMode::Normal)]
+    #[arg(short, long, value_name = "Mode", default_value="normal")]
     mode: StckMode,
 }
 
@@ -82,18 +81,5 @@ fn main() {
             }
         }
         std::process::exit(1);
-    }
-}
-
-impl Display for StckMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Debug => "debug",
-            Self::Normal => "normal",
-            Self::TokenCheck => "token-check",
-            Self::SyntaxCheck => "syntax-check",
-            Self::PrintCode => "print-code",
-        };
-        write!(f, "{s}")
     }
 }

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -22,7 +22,12 @@ enum StckMode {
 fn print_code(code: &stck::internals::Code, import_stack: usize) {
     for expr in code {
         if import_stack != 0 {
-            println!("{} {} @ {}", ">".repeat(import_stack).blue(), expr.cont, expr.span);
+            println!(
+                "{} {} @ {}",
+                ">".repeat(import_stack).blue(),
+                expr.cont,
+                expr.span
+            );
         } else {
             println!("{} @ {}", expr.cont, expr.span);
         }
@@ -64,7 +69,7 @@ fn execute(
 struct Cli {
     file: PathBuf,
 
-    #[arg(short, long, value_name = "Mode", default_value="normal")]
+    #[arg(short, long, value_name = "Mode", default_value = "normal")]
     mode: StckMode,
 }
 

--- a/src/tools/interpreter.rs
+++ b/src/tools/interpreter.rs
@@ -22,9 +22,9 @@ enum StckMode {
 fn print_code(code: &stck::internals::Code, import_stack: usize) {
     for expr in code {
         if import_stack != 0 {
-            println!("{} {}", ">".repeat(import_stack).blue(), expr.cont);
+            println!("{} {} @ {}", ">".repeat(import_stack).blue(), expr.cont, expr.span);
         } else {
-            println!("{}", expr.cont);
+            println!("{} @ {}", expr.cont, expr.span);
         }
         if let stck::internals::ExprCont::IncludedCode(code) = &expr.cont {
             print_code(code, import_stack + 1);


### PR DESCRIPTION
Closes #110

- **testing: storing LineRange instead of char span, some errors**
- **display: use .delta on LineRange instead of manually**
- **cache: on get_span, get at least one line**
- **test/token: fixed for correct line locations, still failing**
- **interpreter: better usage of default value for clap**
- **tests with line span**
- **fixed line span for tokens, still broken in expressions**
- **prelude: better default + `self` on modules**
- **tests/parse: fixed tests, should indicate working parser now**
- **parse: fixed parsing span error**
