### PR TITLE
Error with falty message removed

### DIFF
--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -288,10 +288,6 @@ pub enum RuntimeErrorKind {
         got: Box<Value>,
         expected: &'static str,
     },
-    #[error(
-        "This error should never be elevated to users, if this happens to you, please report it"
-    )]
-    NoSuchBuiltin,
     #[error("The variable {0} is not defined")]
     NoSuchVariable(String),
     #[error(

--- a/lang/src/runtime.rs
+++ b/lang/src/runtime.rs
@@ -263,8 +263,8 @@ impl Context {
         // builtin fn should handle stack pop and push
         // and are always given precedence
         match self.try_execute_builtin(name.as_str(), source) {
-            Ok(()) => return Ok(()),
-            Err(error::RuntimeError::RuntimeRaw(Rtk::NoSuchBuiltin)) => {}
+            Ok(Some(())) => return Ok(()),
+            Ok(None) => {}
             Err(e) => return Err(e),
         }
 
@@ -405,7 +405,7 @@ impl Context {
         Some(())
     }
 
-    fn try_execute_builtin(&mut self, fn_name: &str, source: &Path) -> SResult<()> {
+    fn try_execute_builtin(&mut self, fn_name: &str, source: &Path) -> SResult<Option<()>> {
         match fn_name {
             // seq system
             "print" => {
@@ -788,9 +788,9 @@ impl Context {
             "debug$generics" => eprintln!("{:?}", self.trc),
 
             _ => {
-                return Err(Rtk::NoSuchBuiltin.into());
+                return Ok(None);
             }
         }
-        Ok(())
+        Ok(Some(()))
     }
 }


### PR DESCRIPTION
Closes #124

The error was just a state indicator for an ident not beeing a bultin.
Design was changed to return a `Result<Option<>>``.

An `Option<Result>` was not used for convenience with `?` on the
function body
