### PR TITLE
Interpreter clone using local stck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,8 +209,10 @@ dependencies = [
 name = "stck-examples"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "colored",
  "regex",
- "stck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stck 0.3.1",
  "thiserror",
 ]
 

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -30,6 +30,18 @@ pub enum Error {
     RuntimeError(#[from] RuntimeError),
 }
 
+impl From<RuntimeErrorKind> for Error {
+    fn from(value: RuntimeErrorKind) -> Self {
+        RuntimeError::RuntimeRaw(value).into()
+    }
+}
+
+impl From<RuntimeErrorCtx> for Error {
+    fn from(value: RuntimeErrorCtx) -> Self {
+        RuntimeError::RuntimeCtx(value).into()
+    }
+}
+
 /// # The context of a runtime error
 ///
 /// Error Context, informing the source file's path, the expression

--- a/usage/Cargo.toml
+++ b/usage/Cargo.toml
@@ -5,9 +5,15 @@ edition = "2024"
 
 [dependencies]
 regex = "1.11.1"
-stck = "0.3.0"
+stck = { path = "../lang" }
 thiserror = "2.0.12"
+clap = { version = "4.5.40", features = ["derive"] }
+colored = "3.0.0"
 
 [[bin]]
 name = "calendar"
 path = "src/calendar/main.rs"
+
+[[bin]]
+name = "interpreter"
+path = "src/interpreter/main.rs"

--- a/usage/src/calendar/main.rs
+++ b/usage/src/calendar/main.rs
@@ -1,3 +1,4 @@
+use stck::error::RuntimeErrorCtx;
 use stck::prelude::*;
 use std::collections::HashSet;
 use std::fs::DirEntry;
@@ -46,8 +47,6 @@ enum SError {
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(transparent)]
-    StckRuntime(#[from] error::RuntimeErrorCtx),
-    #[error(transparent)]
     StckError(#[from] error::Error),
     #[error(transparent)]
     Regex(#[from] regex::Error),
@@ -60,6 +59,12 @@ enum SError {
     DidntReturn(String),
     #[error("Program {0} returned: {1:?} instead of a boolean")]
     WrongReturn(String, stck::internals::Value),
+}
+
+impl From<RuntimeErrorCtx> for SError {
+    fn from(value: RuntimeErrorCtx) -> Self {
+        SError::from(error::Error::from(value))
+    }
 }
 
 fn execute() -> Result<(), SError> {

--- a/usage/src/interpreter
+++ b/usage/src/interpreter
@@ -1,0 +1,1 @@
+../../interpreter/src


### PR DESCRIPTION
Closes #131

Interpreter's `src` directory is symlinked into the `usage` crate. There, however, `stck` is included by path, not published version.
