### PR TITLE
Only export errors with context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "stck"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "thiserror",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98eda44a4f6eaf0b01e62e05c218af9719c3f65f733e802f29af162bf10080cc"
+checksum = "c24cf2eca4491218ff1667b72053c38c286610b678c2ccff4928cbe8ad16aa81"
 dependencies = [
  "colored",
  "thiserror",
@@ -212,7 +212,7 @@ dependencies = [
  "clap",
  "colored",
  "regex",
- "stck 0.3.2",
+ "stck 0.3.3",
  "thiserror",
 ]
 
@@ -222,7 +222,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "colored",
- "stck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stck 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/PedroManse/stck"
 readme = "./README.md"
 
 [dependencies]
-stck = "0.3.2"
+stck = "0.3.3"
 clap = { version = "4.5.40", features = ["derive"] }
 colored = "3.0.0"
 

--- a/interpreter/src/main.rs
+++ b/interpreter/src/main.rs
@@ -45,9 +45,7 @@ fn execute(
     match mode {
         M::Normal | M::Debug => {
             let code = get_project_code(file_path, file_cache)?;
-            exec_ctx
-                .execute_entire_code(&code)
-                .map_err(stck::error::RuntimeError::from)?;
+            exec_ctx.execute_entire_code(&code)?;
         }
         M::SyntaxCheck => {
             get_project_code(file_path, file_cache)?;
@@ -78,7 +76,7 @@ fn main() {
 
     if let Err(e) = execute(mode, file, &mut file_cacher, &mut ctx) {
         eprintln!("\n{e}");
-        if let Error::RuntimeError(error::RuntimeError::RuntimeCtx(e)) = e {
+        if let Error::RuntimeError(e) = e {
             let spans: stck::error::ErrorSpans = e.into();
             let sources = spans.try_into_sources(&mut file_cacher).unwrap();
             for source in sources {

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stck"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Manse <pedromanse@duck.com>"]
 license = "GPL-3.0"

--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -138,7 +138,6 @@ fn execute_code(code: &Code) -> SResult<runtime::Context> {
     let mut executioner = runtime::Context::new();
     executioner
         .execute_entire_code(code)
-        .map_err(error::RuntimeError::from)
         .map_err(error::Error::from)?;
     Ok(executioner)
 }

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -7,39 +7,12 @@ use std::collections::hash_map::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
-/// # A runtime error, possibly with a context
-///
-/// Either an [error with context](RuntimeErrorCtx) or [without](RuntimeErrorKind).
-/// However, using the [simple api](crate::api), should always give you a context-full erorr
-///
-/// This error implements [Display](std::fmt::Display) through [Error kind](RuntimeErrorKind) and
-/// [Error Context](RuntimeErrorCtx)
-#[derive(thiserror::Error, Debug)]
-pub enum RuntimeError {
-    #[error(transparent)]
-    RuntimeCtx(#[from] RuntimeErrorCtx),
-    #[error(transparent)]
-    RuntimeRaw(#[from] RuntimeErrorKind),
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
     Anoter(#[from] StckError),
     #[error(transparent)]
-    RuntimeError(#[from] RuntimeError),
-}
-
-impl From<RuntimeErrorKind> for Error {
-    fn from(value: RuntimeErrorKind) -> Self {
-        RuntimeError::RuntimeRaw(value).into()
-    }
-}
-
-impl From<RuntimeErrorCtx> for Error {
-    fn from(value: RuntimeErrorCtx) -> Self {
-        RuntimeError::RuntimeCtx(value).into()
-    }
+    RuntimeError(#[from] RuntimeErrorCtx),
 }
 
 /// # The context of a runtime error

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -7,7 +7,7 @@ pub mod prelude;
 
 // Avaliabe internally
 pub(crate) use error::{
-    ErrCtx, ErrorSource, LineRange, RuntimeError, RuntimeErrorCtx, RuntimeErrorKind, StckError,
+    ErrCtx, ErrorSource, LineRange, RuntimeErrorCtx, RuntimeErrorKind, StckError,
 };
 pub(crate) use internals::*;
 pub(crate) use types::*;

--- a/lang/src/tests/runtime.rs
+++ b/lang/src/tests/runtime.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     api,
     cache::{CacheHelper, NoCache},
-    error::{self, Error},
+    error::Error,
     internals::{RuntimeContext, RustStckFn, Value},
 };
 
@@ -11,9 +11,7 @@ fn execute_string(cont: &str, test_name: &str) -> Result<RuntimeContext, Error> 
     let tokens = api::get_tokens_str(cont, test_name, &mut file_cacher)?;
     let code = api::parse_raw_tokens(tokens)?;
     let mut runtime = RuntimeContext::new();
-    runtime
-        .execute_entire_code(&code)
-        .map_err(error::RuntimeError::from)?;
+    runtime.execute_entire_code(&code)?;
     Ok(runtime)
 }
 
@@ -30,9 +28,7 @@ fn rust_hook() -> Result<(), Error> {
         ctx.execute_entire_code(&code).unwrap();
     });
     runtime.add_rust_hook(hook);
-    runtime
-        .execute_entire_code(&code)
-        .map_err(error::RuntimeError::from)?;
+    runtime.execute_entire_code(&code)?;
     let stack = runtime.get_stack();
     let expected_stack = [Value::Num(4)];
     test_eq!(got: stack, expected: expected_stack);


### PR DESCRIPTION
Closes #130

- **explicit context-full or context-less results on public functions**
- **interpreter: stck v0.3.2 -> v0.3.3**
- **interpreter: remove code path for context-less errors**
