### PR TITLE
Simplify adding context to errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "colored",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stck"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["Manse <pedromanse@duck.com>"]
 license = "GPL-3.0"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -17,6 +17,15 @@ enum RuntimeError {
     RuntimeRaw(#[from] RuntimeErrorKind),
 }
 
+impl RuntimeError {
+    fn add_ctx(self, ctx: ErrCtx) -> RuntimeErrorCtx {
+        match self {
+            RuntimeError::RuntimeRaw(e) => RuntimeErrorCtx::new(ctx, e),
+            RuntimeError::RuntimeCtx(c) => c.append_stack(ctx),
+        }
+    }
+}
+
 type Rtk = crate::error::RuntimeErrorKind;
 type CResult<T> = std::result::Result<T, error::RuntimeErrorCtx>;
 type MixedResult<T> = std::result::Result<T, RuntimeError>;
@@ -182,13 +191,8 @@ impl Context {
     }
 
     fn execute_expr(&mut self, expr: &Expr, source: &Path) -> CResult<ControlFlow> {
-        match self.execute_expr_internal(expr, source) {
-            Ok(c) => Ok(c),
-            Err(RuntimeError::RuntimeRaw(e)) => {
-                Err(RuntimeErrorCtx::new(ErrCtx::new(source, expr), e))
-            }
-            Err(RuntimeError::RuntimeCtx(c)) => Err(c.append_stack(ErrCtx::new(source, expr))),
-        }
+        self.execute_expr_internal(expr, source)
+            .map_err(|e| e.add_ctx(ErrCtx::new(source, expr)))
     }
 
     fn execute_expr_internal(&mut self, expr: &Expr, source: &Path) -> MixedResult<ControlFlow> {
@@ -283,7 +287,10 @@ impl Context {
                     None => ControlFlow::Continue,
                 }
             }
-            KeywordKind::Ifs { branches, otherwhise } => {
+            KeywordKind::Ifs {
+                branches,
+                otherwhise,
+            } => {
                 for branch in branches {
                     if self.execute_check(&branch.check, source)? {
                         return self
@@ -292,7 +299,9 @@ impl Context {
                     }
                 }
                 if let Some(else_code) = otherwhise {
-                    return self.execute_code(else_code, source).map_err(RuntimeError::from);
+                    return self
+                        .execute_code(else_code, source)
+                        .map_err(RuntimeError::from);
                 }
                 ControlFlow::Continue
             }

--- a/usage/Cargo.lock
+++ b/usage/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "stck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "colored",
  "thiserror",


### PR DESCRIPTION
- **runtime: simpler execute_expr**
- **v1.2.0 -> v1.2.1**
