### PR TITLE
Overwrite entry on cache system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "colored",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stck"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2024"
 authors = ["Manse <pedromanse@duck.com>"]
 license = "GPL-3.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,6 +25,10 @@ pub trait FileCacher {
     }
 }
 
+pub trait OverwriteCache {
+    fn overwrite(&mut self, path: impl AsRef<Path>, content: String);
+}
+
 /// # Caching system for files
 ///
 /// Used with [Line range](LineRange) to read specific lines from files on [get span](ErrorHelper::get_span)
@@ -45,6 +49,12 @@ pub struct CachedFile<'s>(OccupiedEntry<'s, PathBuf, String>);
 impl AsRef<str> for CachedFile<'_> {
     fn as_ref(&self) -> &str {
         self.0.get()
+    }
+}
+
+impl OverwriteCache for CacheHelper {
+    fn overwrite(&mut self, path: impl AsRef<Path>, content: String) {
+        self.files.insert(path.as_ref().to_path_buf(), content);
     }
 }
 
@@ -78,18 +88,28 @@ impl FileCacher for NoCache {
 }
 
 #[derive(Default)]
+#[deprecated]
 pub struct MockFileCacher(CacheHelper);
 
+#[allow(deprecated)]
 impl MockFileCacher {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
     pub fn mock_file(&mut self, path: PathBuf, content: String) {
-        self.0.files.insert(path, content);
+        self.0.overwrite(path, content);
     }
 }
 
+#[allow(deprecated)]
+impl OverwriteCache for MockFileCacher {
+    fn overwrite(&mut self, path: impl AsRef<Path>, content: String) {
+        self.mock_file(path.as_ref().to_path_buf(), content);
+    }
+}
+
+#[allow(deprecated)]
 impl FileCacher for MockFileCacher {
     type FileRecord<'s> = CachedFile<'s>;
     fn read_file(
@@ -122,6 +142,12 @@ impl Isolated {
         let cont = std::fs::read_to_string(&path)?;
         self.allowed.insert(path, cont);
         Ok(())
+    }
+}
+
+impl OverwriteCache for Isolated {
+    fn overwrite(&mut self, path: impl AsRef<Path>, content: String) {
+        self.allowed.insert(path.as_ref().to_path_buf(), content);
     }
 }
 

--- a/usage/Cargo.lock
+++ b/usage/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "stck"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "colored",
  "thiserror",


### PR DESCRIPTION
Caching systems that implement `FileCacher` may implement `OverwriteCache` to allow the host to overwrite an entry in the system

This makes `MockFileCacher` useless, since `Isolated` or `CacheHelper` can be used and overwritten.

Closes #175
