### PR TITLE
Buitin modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "colored",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stck"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2024"
 authors = ["Manse <pedromanse@duck.com>"]
 license = "GPL-3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,8 +223,6 @@ pub enum StckError {
     UnknownType(String),
     #[error("Can't parse TRC `{0}`, missing name")]
     TRCMissingName(String),
-    #[error("Tried making a builtin module without a # prefix")]
-    BuiltinModuleWithoutBang(String),
     #[error("Hosts can't make modules with the # prefix (sign of builtin module)")]
     UserModuleWithBang(String),
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1005,15 +1005,6 @@ impl Context {
                 self.stack.push_this(is_type);
             }
 
-            // seq debug
-            "debug$stack" => eprintln!("{:?}", self.stack),
-            "Debug$stack" => eprintln!("{}", self.stack),
-            "debug$vars" => eprintln!("{:?}", self.vars),
-            "debug$args" => eprintln!("{:?}", self.args),
-            "debug$fns" => eprintln!("{:?}", self.fns),
-            "debug$modules" => eprintln!("{:?}", self.enabled_modules),
-            "debug$generics" => eprintln!("{:?}", self.trc),
-
             _ => {
                 return Ok(None);
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,6 +9,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
+use self::module::{IntoModules, Module};
+
 #[derive(thiserror::Error, Debug)]
 enum RuntimeError {
     #[error(transparent)]
@@ -75,6 +77,13 @@ impl Context {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn register_module(&mut self, module_group: impl IntoModules) {
+        for Module { funcs, name } in module_group.into_modules() {
+            self.rust_fns.extend(funcs);
+            self.enabled_modules.insert(name);
+        }
     }
 
     pub fn add_module(&mut self, module: module::Module) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -76,6 +76,13 @@ pub struct Context {
 impl Context {
     #[must_use]
     pub fn new() -> Self {
+        let mut ctx = Self::default();
+        ctx.register_module(module::builtin_modules());
+        ctx
+    }
+
+    #[must_use]
+    pub fn new_raw() -> Self {
         Self::default()
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -957,33 +957,6 @@ impl Context {
                 self.stack.push_this(v);
             }
 
-            // seq map
-            "map$new" => {
-                self.stack.push_this(HashMap::new());
-            }
-            "map$insert-kv" => {
-                let value = stack_pop!(
-                    (self.stack) -> * as "value" for fn_name
-                )?;
-                let key = stack_pop!(
-                    (self.stack) -> str as "key" for fn_name
-                )?;
-                let mut map = stack_pop!(
-                    (self.stack) -> map as "map" for fn_name
-                )?;
-                map.insert(key, value);
-                self.stack.push_this(map);
-            }
-            "map$get" => {
-                let key = stack_pop!(
-                    (self.stack) -> str as "key" for fn_name
-                )?;
-                let got = stack_pop!((self.stack) -> &map as "map" for fn_name)?
-                    .get(&key)
-                    .cloned();
-                self.stack.push_this(got);
-            }
-
             // seq type
             "type$is-str" => {
                 let is_type = stack_pop!((self.stack) -> str as "value" for fn_name).is_ok();

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -64,6 +64,7 @@ where
 
 pub mod debug;
 pub mod io;
+pub mod map;
 
 #[deprecated]
 pub mod oficial {
@@ -77,6 +78,7 @@ pub fn builtin_modules() -> impl IntoModules {
     [
         debug::make(),
         io::make(),
+        map::make(),
     ]
 }
 

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -1,12 +1,27 @@
 mod io;
+mod debug;
 pub mod oficial {
-    pub use super::io::io_module;
+    pub use super::io::*;
+    pub use super::debug::*;
 }
 
 use crate::{FnName, StckError};
 use std::collections::HashMap;
 
 use super::Hook;
+
+macro_rules! register {
+    ($mod:expr, $name:ident as |$ctx:ident| $fn:block) => {
+        fn $name($ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> $fn
+        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
+    };
+    ($mod:expr, $name:ident as |$ctx:ident, $path: ident| $fn:block) => {
+        fn $name($ctx: &mut RuntimeContext, $path: &Path) -> Result<(), RuntimeErrorKind> $fn
+        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
+    };
+}
+pub(crate) use register;
+
 
 #[derive(Clone)]
 pub struct Module {
@@ -25,15 +40,9 @@ impl Module {
             })
         }
     }
-    fn new_protected(name: String) -> Result<Module, StckError> {
-        if name.starts_with('#') {
-            Ok(Module {
-                name,
-                funcs: HashMap::new(),
-            })
-        } else {
-            Err(StckError::BuiltinModuleWithoutBang(name))
-        }
+    fn new_protected(name: &'static str) -> Module {
+        let name = format!("#{name}");
+        Module { name, funcs: HashMap::new() }
     }
     pub fn add_fn(&mut self, name: impl Into<String>, fnc: Hook) -> Option<Hook> {
         self.funcs.insert(name.into(), fnc)

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -1,6 +1,6 @@
+use super::Hook;
 use crate::{FnName, StckError};
 use std::collections::HashMap;
-use super::Hook;
 
 macro_rules! register {
     ($mod:expr, $name:ident as |$ctx:ident| $fn:block) => {
@@ -69,16 +69,12 @@ pub mod map;
 #[deprecated]
 pub mod oficial {
     pub use super::debug::make as debug;
-    pub use super::io::make as io;
     #[allow(deprecated)]
     pub use super::io::io_module;
+    pub use super::io::make as io;
 }
 
+#[must_use]
 pub fn builtin_modules() -> impl IntoModules {
-    [
-        debug::make(),
-        io::make(),
-        map::make(),
-    ]
+    [debug::make(), io::make(), map::make()]
 }
-

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -1,13 +1,5 @@
-mod io;
-mod debug;
-pub mod oficial {
-    pub use super::io::*;
-    pub use super::debug::*;
-}
-
 use crate::{FnName, StckError};
 use std::collections::HashMap;
-
 use super::Hook;
 
 macro_rules! register {
@@ -21,7 +13,6 @@ macro_rules! register {
     };
 }
 pub(crate) use register;
-
 
 #[derive(Clone)]
 pub struct Module {
@@ -42,9 +33,50 @@ impl Module {
     }
     fn new_protected(name: &'static str) -> Module {
         let name = format!("#{name}");
-        Module { name, funcs: HashMap::new() }
+        Module {
+            name,
+            funcs: HashMap::new(),
+        }
     }
     pub fn add_fn(&mut self, name: impl Into<String>, fnc: Hook) -> Option<Hook> {
         self.funcs.insert(name.into(), fnc)
     }
 }
+
+pub trait IntoModules {
+    fn into_modules(self) -> impl Iterator<Item = Module>;
+}
+
+impl IntoModules for Module {
+    fn into_modules(self) -> impl Iterator<Item = Module> {
+        std::iter::once(self)
+    }
+}
+
+impl<II> IntoModules for II
+where
+    II: IntoIterator<Item = Module>,
+{
+    fn into_modules(self) -> impl Iterator<Item = Module> {
+        self.into_iter()
+    }
+}
+
+pub mod debug;
+pub mod io;
+
+#[deprecated]
+pub mod oficial {
+    pub use super::debug::make as debug;
+    pub use super::io::make as io;
+    #[allow(deprecated)]
+    pub use super::io::io_module;
+}
+
+pub fn builtin_modules() -> impl IntoModules {
+    [
+        debug::make(),
+        io::make(),
+    ]
+}
+

--- a/src/runtime/module/debug.rs
+++ b/src/runtime/module/debug.rs
@@ -24,7 +24,7 @@ fn debug_generics(ctx: &mut RuntimeContext, _: &Path) {
     println!("{:?}", ctx.trc);
 }
 
-pub fn debug() -> Module {
+pub fn make() -> Module {
     let mut debug_mod = Module::new_protected("debug");
     debug_mod.add_fn("debug$stack", Hook::Raw(debug_stack));
     debug_mod.add_fn("Debug$stack", Hook::Raw(debug_stack_pretty));

--- a/src/runtime/module/debug.rs
+++ b/src/runtime/module/debug.rs
@@ -1,0 +1,37 @@
+use super::*;
+use crate::RuntimeContext;
+use std::path::Path;
+
+fn debug_stack(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.stack);
+}
+fn debug_stack_pretty(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{}", ctx.stack);
+}
+fn debug_vars(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.vars);
+}
+fn debug_args(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.args);
+}
+fn debug_fns(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.fns);
+}
+fn debug_modules(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.enabled_modules);
+}
+fn debug_generics(ctx: &mut RuntimeContext, _: &Path) {
+    println!("{:?}", ctx.trc);
+}
+
+pub fn debug() -> Module {
+    let mut debug_mod = Module::new_protected("debug");
+    debug_mod.add_fn("debug$stack", Hook::Raw(debug_stack));
+    debug_mod.add_fn("Debug$stack", Hook::Raw(debug_stack_pretty));
+    debug_mod.add_fn("debug$vars", Hook::Raw(debug_vars));
+    debug_mod.add_fn("debug$args", Hook::Raw(debug_args));
+    debug_mod.add_fn("debug$fns", Hook::Raw(debug_fns));
+    debug_mod.add_fn("debug$modules", Hook::Raw(debug_modules));
+    debug_mod.add_fn("debug$generics", Hook::Raw(debug_generics));
+    debug_mod
+}

--- a/src/runtime/module/io.rs
+++ b/src/runtime/module/io.rs
@@ -1,22 +1,12 @@
 use crate::{
-    RuntimeContext, RuntimeErrorKind, StckError, Value,
     runtime::{Hook, module::Module, sget, stack_pop},
+    RuntimeContext, RuntimeErrorKind, StckError, Value,
 };
 use std::{io::Write, path::Path};
+use super::register;
 
-macro_rules! register {
-    ($mod:expr, $name:ident as |$ctx:ident| $fn:block) => {
-        fn $name($ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> $fn
-        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
-    };
-    ($mod:expr, $name:ident as |$ctx:ident, $path: ident| $fn:block) => {
-        fn $name($ctx: &mut RuntimeContext, $path: &Path) -> Result<(), RuntimeErrorKind> $fn
-        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
-    };
-}
-
-pub fn io_module() -> Result<Module, StckError> {
-    let mut io_mod = Module::new_protected("#io".to_string())?;
+pub fn io() -> Module {
+    let mut io_mod = Module::new_protected("io");
 
     register!(io_mod, read_file as |ctx| {
         let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
@@ -67,5 +57,10 @@ pub fn io_module() -> Result<Module, StckError> {
         Ok(())
     });
 
-    Ok(io_mod)
+    io_mod
+}
+
+#[deprecated]
+pub fn io_module() -> Result<Module, StckError> {
+    Ok(io())
 }

--- a/src/runtime/module/io.rs
+++ b/src/runtime/module/io.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{io::Write, path::Path};
 use super::register;
 
-pub fn io() -> Module {
+pub fn make() -> Module {
     let mut io_mod = Module::new_protected("io");
 
     register!(io_mod, read_file as |ctx| {
@@ -62,5 +62,5 @@ pub fn io() -> Module {
 
 #[deprecated]
 pub fn io_module() -> Result<Module, StckError> {
-    Ok(io())
+    Ok(make())
 }

--- a/src/runtime/module/io.rs
+++ b/src/runtime/module/io.rs
@@ -1,9 +1,9 @@
+use super::register;
 use crate::{
-    runtime::{Hook, module::Module, sget, stack_pop},
     RuntimeContext, RuntimeErrorKind, StckError, Value,
+    runtime::{Hook, module::Module, sget, stack_pop},
 };
 use std::{io::Write, path::Path};
-use super::register;
 
 pub fn make() -> Module {
     let mut io_mod = Module::new_protected("io");

--- a/src/runtime/module/map.rs
+++ b/src/runtime/module/map.rs
@@ -1,0 +1,46 @@
+use crate::runtime::{sget, stack_pop};
+use crate::{
+    RuntimeContext, RuntimeErrorKind, Value,
+    runtime::{Hook, Module},
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+fn map_new(ctx: &mut RuntimeContext, _: &Path) {
+    ctx.stack.push_this(HashMap::new());
+}
+
+fn map_insert(ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> {
+    let value = stack_pop!(
+        (ctx.stack) -> * as "value" for "map-insert-kv"
+    )?;
+    let key = stack_pop!(
+        (ctx.stack) -> str as "key" for "map-insert-kv"
+    )?;
+    let mut map = stack_pop!(
+        (ctx.stack) -> map as "map" for "map-insert-kv"
+    )?;
+    map.insert(key, value);
+    ctx.stack.push_this(map);
+    Ok(())
+}
+
+fn map_get(ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> {
+    let key = stack_pop!(
+        (ctx.stack) -> str as "key" for "map$get"
+    )?;
+    let got = stack_pop!((ctx.stack) -> &map as "map" for "map$get")?
+        .get(&key)
+        .cloned();
+    ctx.stack.push_this(got);
+    Ok(())
+}
+
+pub fn make() -> Module {
+    let mut map_mod = Module::new_protected("map");
+    map_mod.add_fn("map$new", Hook::Raw(map_new));
+    map_mod.add_fn("map$insert", Hook::WithError(map_insert));
+    map_mod.add_fn("map$insert-kv", Hook::WithError(map_insert));
+    map_mod.add_fn("map$get", Hook::WithError(map_get));
+    map_mod
+}

--- a/usage/Cargo.lock
+++ b/usage/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "stck"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "colored",
  "thiserror",

--- a/usage/src/interpreter/main.rs
+++ b/usage/src/interpreter/main.rs
@@ -1,11 +1,10 @@
-use stck::internals::module;
 use stck::prelude::*;
 
 fn main() -> Result<(), stck::Error> {
     let file_path = std::env::args().nth(1).unwrap();
     let mut file_cacher = CacheHelper::new();
     let mut exec_ctx = RuntimeContext::new();
-    exec_ctx.add_module(module::oficial::io_module()?);
+    exec_ctx.register_module(internals::module::io::make());
     let code = get_project_code(file_path, &mut file_cacher)?;
     if let Err(e) = exec_ctx.execute_entire_code(&code) {
         println!("{e}");


### PR DESCRIPTION
Closes #154

- **modules: register\! macro in module.rs, error-less io mod**
- **mod,err: removed now useless error (builtin mods get # automatically)**
- **debug module**
- **debug modules + better usage**
- **map module**
- **ci**
- **runtime: Context::new function now loads all builtin modules, new_raw doesn't**
- **v1.6**
- **usage: stop using deprecated io module**
