### PR TITLE
Removed protected modules

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 
-use self::module::{IntoModules, Module};
+use self::module::Module;
 
 #[derive(thiserror::Error, Debug)]
 enum RuntimeError {
@@ -77,7 +77,7 @@ impl Context {
     #[must_use]
     pub fn new() -> Self {
         let mut ctx = Self::default();
-        ctx.register_module(module::builtin_modules());
+        ctx.register_modules(module::get_builtin_modules());
         ctx
     }
 
@@ -86,13 +86,23 @@ impl Context {
         Self::default()
     }
 
-    pub fn register_module(&mut self, module_group: impl IntoModules) {
+    pub fn register_modules(&mut self, module_group: impl IntoIterator<Item = Module>) {
+        for Module { funcs, name } in module_group {
+            self.rust_fns.extend(funcs);
+            self.enabled_modules.insert(name);
+        }
+    }
+
+    #[allow(deprecated)]
+    #[deprecated]
+    pub fn register_module(&mut self, module_group: impl module::IntoModules) {
         for Module { funcs, name } in module_group.into_modules() {
             self.rust_fns.extend(funcs);
             self.enabled_modules.insert(name);
         }
     }
 
+    #[deprecated]
     pub fn add_module(&mut self, module: module::Module) {
         self.rust_fns.extend(module.funcs);
         self.enabled_modules.insert(module.name);

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -28,6 +28,7 @@ pub struct Module {
 
 impl Module {
     /// Create an empty module
+    #[must_use]
     pub fn empty(name: String) -> Module {
         Module {
             name,
@@ -81,6 +82,6 @@ pub mod oficial {
 }
 
 #[must_use]
-pub(crate) fn get_builtin_modules() -> impl IntoIterator<Item=Module> {
+pub(crate) fn get_builtin_modules() -> impl IntoIterator<Item = Module> {
     [debug::make(), io::make(), map::make()]
 }

--- a/src/runtime/module.rs
+++ b/src/runtime/module.rs
@@ -1,19 +1,25 @@
+//! # Host-defined stck functions
+//!
+//! Modules are named collections of functions that can be registered on a runtime environment for
+//! users to execute.
+//!
+//! They can be created with [`Module::empty`], named [Hooks](Hook) can be added with
+//! [`Module::add_fn`] and can be registered on a runtime with
+//! [`RuntimeContext::register_module`](crate::RuntimeContext::register_module), then all the
+//! functions from the module will be avaliable to the user by their name as if they where builtin.
+//!
+//! After registering a module it's impossible to remove it's functions from a runtime context.
+//!
+//! By default runtime is instantiated with the modules: [ [`debug`], [`io`] and [`map`] ]. But it
+//! is possible to create a runtime with no loaded modules with
+//! [`RuntimeContext::new_raw`](crate::RuntimeContext::new_raw)
+//!
+
 use super::Hook;
 use crate::{FnName, StckError};
 use std::collections::HashMap;
 
-macro_rules! register {
-    ($mod:expr, $name:ident as |$ctx:ident| $fn:block) => {
-        fn $name($ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> $fn
-        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
-    };
-    ($mod:expr, $name:ident as |$ctx:ident, $path: ident| $fn:block) => {
-        fn $name($ctx: &mut RuntimeContext, $path: &Path) -> Result<(), RuntimeErrorKind> $fn
-        $mod.add_fn(format!("io${}", stringify!($name)), Hook::WithError($name));
-    };
-}
-pub(crate) use register;
-
+/// # A named collection of functions
 #[derive(Clone)]
 pub struct Module {
     pub(crate) name: String,
@@ -21,44 +27,44 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn new(name: String) -> Result<Module, StckError> {
-        if name.starts_with('#') {
-            Err(StckError::UserModuleWithBang(name))
-        } else {
-            Ok(Module {
-                name,
-                funcs: HashMap::new(),
-            })
-        }
-    }
-    fn new_protected(name: &'static str) -> Module {
-        let name = format!("#{name}");
+    /// Create an empty module
+    pub fn empty(name: String) -> Module {
         Module {
             name,
             funcs: HashMap::new(),
         }
     }
+    /// Add a function to a module
     pub fn add_fn(&mut self, name: impl Into<String>, fnc: Hook) -> Option<Hook> {
         self.funcs.insert(name.into(), fnc)
     }
+
+    #[deprecated]
+    pub fn new(name: String) -> Result<Module, StckError> {
+        Ok(Module {
+            name,
+            funcs: HashMap::new(),
+        })
+    }
 }
 
-pub trait IntoModules {
-    fn into_modules(self) -> impl Iterator<Item = Module>;
-}
-
-impl IntoModules for Module {
-    fn into_modules(self) -> impl Iterator<Item = Module> {
+impl IntoIterator for Module {
+    type Item = Module;
+    type IntoIter = std::iter::Once<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
         std::iter::once(self)
     }
 }
 
-impl<II> IntoModules for II
-where
-    II: IntoIterator<Item = Module>,
-{
+#[deprecated]
+pub trait IntoModules {
+    fn into_modules(self) -> impl Iterator<Item = Module>;
+}
+
+#[allow(deprecated)]
+impl IntoModules for Module {
     fn into_modules(self) -> impl Iterator<Item = Module> {
-        self.into_iter()
+        std::iter::once(self)
     }
 }
 
@@ -75,6 +81,6 @@ pub mod oficial {
 }
 
 #[must_use]
-pub fn builtin_modules() -> impl IntoModules {
+pub(crate) fn get_builtin_modules() -> impl IntoIterator<Item=Module> {
     [debug::make(), io::make(), map::make()]
 }

--- a/src/runtime/module/debug.rs
+++ b/src/runtime/module/debug.rs
@@ -25,7 +25,7 @@ fn debug_generics(ctx: &mut RuntimeContext, _: &Path) {
 }
 
 pub fn make() -> Module {
-    let mut debug_mod = Module::new_protected("debug");
+    let mut debug_mod = Module::empty("debug".to_string());
     debug_mod.add_fn("debug$stack", Hook::Raw(debug_stack));
     debug_mod.add_fn("Debug$stack", Hook::Raw(debug_stack_pretty));
     debug_mod.add_fn("debug$vars", Hook::Raw(debug_vars));

--- a/src/runtime/module/io.rs
+++ b/src/runtime/module/io.rs
@@ -1,62 +1,43 @@
-use super::register;
 use crate::{
     RuntimeContext, RuntimeErrorKind, StckError, Value,
     runtime::{Hook, module::Module, sget, stack_pop},
 };
 use std::{io::Write, path::Path};
 
+fn read_file(ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> {
+    let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
+    let content = std::fs::read_to_string(path);
+    let r = match content {
+        Ok(o) => Ok(Value::from(o)),
+        Err(e) => Err(Value::from(e.to_string())),
+    };
+    ctx.stack.push_this(r);
+    Ok(())
+}
+
+fn write_file(ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> {
+    let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
+    let content = stack_pop!((ctx.stack) -> str as "file content" for "io$read-file")?;
+    let file = std::fs::OpenOptions::new().append(true).open(path);
+    let mut file = match file {
+        Ok(o) => o,
+        Err(e) => {
+            ctx.stack.push_this(Err(e.to_string().into()));
+            return Ok(());
+        }
+    };
+    let res = match file.write_all(content.as_bytes()) {
+        Err(e) => Err((e.to_string()).into()),
+        Ok(()) => Ok((content.len() as isize).into()),
+    };
+    ctx.stack.push_this(res);
+    Ok(())
+}
+
 pub fn make() -> Module {
-    let mut io_mod = Module::new_protected("io");
-
-    register!(io_mod, read_file as |ctx| {
-        let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
-        let content = std::fs::read_to_string(path);
-        let r = match content {
-            Ok(o) => Ok(Value::from(o)),
-            Err(e) => Err(Value::from(e.to_string())),
-        };
-        ctx.stack.push_this(r);
-        Ok(())
-    });
-
-    register!(io_mod, write_file as |ctx| {
-        let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
-        let content = stack_pop!((ctx.stack) -> str as "file content" for "io$read-file")?;
-        let file = std::fs::File::create(path);
-        let mut file = match file {
-            Ok(o) => o,
-            Err(e) => {
-                ctx.stack.push_this(Err(e.to_string().into()));
-                return Ok(());
-            }
-        };
-        let res = match file.write_all(content.as_bytes()) {
-            Err(e)=> Err((e.to_string()).into()),
-            Ok(()) => Ok((content.len() as isize).into()),
-        };
-        ctx.stack.push_this(res);
-        Ok(())
-    });
-
-    register!(io_mod, append_file as |ctx| {
-        let path = stack_pop!((ctx.stack) -> str as "file path" for "io$read-file")?;
-        let content = stack_pop!((ctx.stack) -> str as "file content" for "io$read-file")?;
-        let file = std::fs::OpenOptions::new().append(true).open(path);
-        let mut file = match file {
-            Ok(o) => o,
-            Err(e) => {
-                ctx.stack.push_this(Err(e.to_string().into()));
-                return Ok(());
-            }
-        };
-        let res = match file.write_all(content.as_bytes()) {
-            Err(e)=> Err((e.to_string()).into()),
-            Ok(()) => Ok((content.len() as isize).into()),
-        };
-        ctx.stack.push_this(res);
-        Ok(())
-    });
-
+    let mut io_mod = Module::empty("io".to_string());
+    io_mod.add_fn("io$read-file", Hook::WithError(read_file));
+    io_mod.add_fn("io$write-file", Hook::WithError(write_file));
     io_mod
 }
 

--- a/src/runtime/module/map.rs
+++ b/src/runtime/module/map.rs
@@ -37,7 +37,7 @@ fn map_get(ctx: &mut RuntimeContext, _: &Path) -> Result<(), RuntimeErrorKind> {
 }
 
 pub fn make() -> Module {
-    let mut map_mod = Module::new_protected("map");
+    let mut map_mod = Module::empty("map".to_string());
     map_mod.add_fn("map$new", Hook::Raw(map_new));
     map_mod.add_fn("map$insert", Hook::WithError(map_insert));
     map_mod.add_fn("map$insert-kv", Hook::WithError(map_insert));

--- a/src/token.rs
+++ b/src/token.rs
@@ -248,10 +248,18 @@ impl Context {
                                 .map(str::trim)
                                 .map(String::from)
                                 .map(RawKeyword::Require);
+                            // In case of old (require) invocations regarding protected
+                            // modules, simply remove the # prefix
+                            let require_old_protected = otherwise
+                                .strip_prefix("require #")
+                                .map(str::trim)
+                                .map(String::from)
+                                .map(RawKeyword::Require);
                             include
                                 .or(pragma)
                                 .or(fn_into_closure)
                                 .or(trc)
+                                .or(require_old_protected)
                                 .or(require)
                                 .ok_or(StckError::UnknownKeyword(otherwise.to_string()))?
                         }


### PR DESCRIPTION
Closes #192

* Also adds some docs
* Old usages have been deprecated
* Old `(require #<mod>)` still works by removing the # prefix

