### PR TITLE
Remove impossible codepath from tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "colored",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stck"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 authors = ["Manse <pedromanse@duck.com>"]
 license = "GPL-3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,6 +223,7 @@ pub enum StckError {
     CantParseToken(parse::State, Box<TokenCont>, PathBuf),
     #[error("Unknown keyword: {0}")]
     UnknownKeyword(String),
+    #[deprecated]
     #[error("Missing char")]
     MissingChar,
     #[error("Can't make closure with zero arguments, it's code spans these bytes: {span}")]

--- a/src/token.rs
+++ b/src/token.rs
@@ -381,27 +381,19 @@ impl Context {
                 }
             }
         }
-        if self.at_eof() {
-            match state {
-                Nothing | OnComment => {}
-                MakeIdent(s) => {
-                    self.push_token(&mut out, Ident(s));
-                }
-                MakeNumber(buf) => {
-                    let num = buf.parse()?;
-                    self.push_token(&mut out, Number(num));
-                }
-                s => return Err(StckError::UnexpectedEOF(s)),
+        match state {
+            Nothing | OnComment => {}
+            MakeIdent(s) => {
+                self.push_token(&mut out, Ident(s));
             }
-            self.push_token(&mut out, EndOfBlock);
-            Ok(out)
-        } else {
-            Err(crate::StckError::MissingChar)
+            MakeNumber(buf) => {
+                let num = buf.parse()?;
+                self.push_token(&mut out, Number(num));
+            }
+            s => return Err(StckError::UnexpectedEOF(s)),
         }
-    }
-
-    fn at_eof(&self) -> bool {
-        self.point == self.chars.len()
+        self.push_token(&mut out, EndOfBlock);
+        Ok(out)
     }
 
     fn next(&mut self) -> Option<&char> {

--- a/usage/Cargo.lock
+++ b/usage/Cargo.lock
@@ -189,7 +189,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "stck"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "colored",
  "thiserror",


### PR DESCRIPTION
Closes #200

- **token: removed impossible code path: no more tokens but file didn't end**
- **v2.0.1**
