### PR TITLE
Try keyword

### DIFF
--- a/examples/stdlib/stck.stck
+++ b/examples/stdlib/stck.stck
@@ -12,6 +12,7 @@
 (include math.stck)
 (include error.stck)
 (include string.stck)
+(include vars.stck)
 
 (include argv.stck)
 (include print.stck)

--- a/examples/stdlib/vars.stck
+++ b/examples/stdlib/vars.stck
@@ -1,2 +1,2 @@
 # global function will pass on defined variables as globals
-(fn*) [ name<str> value<T> ] [] { name value set }
+(fn*) [ name<str> value<T> ] [] set-global { name value set }

--- a/examples/stdlib/vars.stck
+++ b/examples/stdlib/vars.stck
@@ -1,0 +1,2 @@
+# global function will pass on defined variables as globals
+(fn*) [ name<str> value<T> ] [] { name value set }

--- a/examples/try.stck
+++ b/examples/try.stck
@@ -1,0 +1,10 @@
+(pragma set debug)
+(include stdlib)
+
+(fn) [ a<num> b<num> ] [ r<num> ] div {
+	a b /
+}
+
+10 0 (try div) prt
+
+[ a b ] { a b / ! }

--- a/examples/try.stck
+++ b/examples/try.stck
@@ -4,7 +4,6 @@
 (fn) [ a<num> b<num> ] [ r<num> ] div {
 	a b /
 }
-
 10 0 (try div) prt
 
-[ a b ] { a b / ! }
+[ a b ] { a b / } 10 @ 3 (try @) prt

--- a/src/display.rs
+++ b/src/display.rs
@@ -100,6 +100,8 @@ impl Display for ExprCont {
             Self::Keyword(k) => {
                 write!(f, "Keyword: ")?;
                 match k {
+                    KeywordKind::TryClosure => write!(f, "Try executing closure"),
+                    KeywordKind::Try { fn_name } => write!(f, "Try executing function {fn_name}"),
                     KeywordKind::Structure { name, .. } => write!(f, "Struct {name}"),
                     KeywordKind::Require(mn) => write!(f, "Require module {mn}"),
                     KeywordKind::DefinedGeneric(g) => write!(f, "Define generic {g:?}"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,8 +34,8 @@ impl_from!(RuntimeErrorCtx => Error by Error::RuntimeError);
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::RuntimeError(r) => r.fmt(f),
-            Self::Anoter(a) => a.fmt(f),
+            Self::RuntimeError(r) => write!(f, "{r}"),
+            Self::Anoter(a) => write!(f, "{a}"),
         }
     }
 }
@@ -281,7 +281,7 @@ impl Display for StckError {
             }
             Self::CantParseToken(state, tkn, file) => {
                 format!(
-                    "Parser in file {path}: State ({state:?}): {state} doesn't accept token: {tkn:?}",
+                    "Parser in file {path}: State {state} doesn't accept token: {tkn:?}",
                     path = file.display().to_string().green(),
                     state = state.to_string().yellow()
                 )
@@ -403,6 +403,7 @@ pub enum RuntimeErrorKind {
         Rc<UserStructDef>,
     ),
     DisallowedAction(UnauthorizedAction),
+    DivByZero(isize),
 }
 
 impl std::error::Error for RuntimeErrorKind {}
@@ -514,6 +515,7 @@ impl Display for RuntimeErrorKind {
                 format!("Wrong value, {val}, for type {typ}, while doing {meth:?} on {user_struct}")
             }
             Self::DisallowedAction(act) => format!("Tried to execute dissalowed action: {act}"),
+            Self::DivByZero(n) => format!("Tried to divide {n} by zero"),
         };
         f.write_str(&s)
     }

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -842,6 +842,10 @@ pub enum KeywordKind {
     },
     DefinedGeneric(DefinedGenericBuilder),
     Require(String),
+    Try {
+        fn_name: String,
+    },
+    TryClosure,
 }
 
 #[cfg_attr(test, derive(PartialEq))]
@@ -900,6 +904,8 @@ pub enum RawKeyword {
     Switch,
     Break,
     Require(String),
+    Try(String),
+    TryClosure,
 }
 
 #[cfg_attr(test, derive(PartialEq))]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -91,6 +91,14 @@ impl<'p> Context<'p> {
                     push_expr!(E::Keyword(KeywordKind::DefinedGeneric(trc)));
                     Nothing
                 }
+                (Nothing, Keyword(RawKeyword::Try(fn_name))) => {
+                    push_expr!(E::Keyword(KeywordKind::Try { fn_name }));
+                    Nothing
+                }
+                (Nothing, Keyword(RawKeyword::TryClosure)) => {
+                    push_expr!(E::Keyword(KeywordKind::TryClosure));
+                    Nothing
+                }
                 (Nothing, Keyword(RawKeyword::Require(module_name))) => {
                     push_expr!(E::Keyword(KeywordKind::Require(module_name)));
                     Nothing

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -322,6 +322,45 @@ impl<'p> Context<'p> {
                 self.user_structures.insert(Rc::new(stct));
                 ControlFlow::Continue
             }
+            KeywordKind::Try { fn_name } => {
+                let fn_def = self
+                    .find_user_fn(fn_name)
+                    .ok_or(RuntimeErrorKind::MissingIdent(fn_name.clone()))?;
+                colored::control::SHOULD_COLORIZE.set_override(false);
+                let rets = self
+                    .execute_user_fn(fn_name, fn_def)
+                    .map(Value::Array)
+                    .map_err(|e| e.to_string())
+                    .map_err(Value::Str);
+                colored::control::SHOULD_COLORIZE.unset_override();
+                self.stack.push_this(rets);
+                ControlFlow::Continue
+            }
+            KeywordKind::TryClosure => {
+                let v = stack_pop!((self.stack) -> * as "value" for "(try @) keyword")?;
+                let cl = stack_pop!((self.stack) -> closure as "closure" for "(try @) keyword")?;
+                let cl = cl.fill(v).map_err(|e| e.to_string()).map_err(Value::Str);
+
+                match cl {
+                    Err(s) => {
+                        self.stack.push_this(s);
+                    }
+                    Ok(ClosureCurry::Partial(cl)) => {
+                        self.stack.push_this(cl);
+                    }
+                    Ok(ClosureCurry::Full(cl)) => {
+                        colored::control::SHOULD_COLORIZE.set_override(false);
+                        let result = self
+                            .try_execute_user_closure(cl, source)
+                            .map_err(|e| e.to_string())
+                            .map_err(Value::Str)
+                            .map(Value::Array);
+                        colored::control::SHOULD_COLORIZE.unset_override();
+                        self.stack.push_this(Value::Result(Box::new(result)));
+                    }
+                }
+                ControlFlow::Continue
+            }
             KeywordKind::Require(module_name) => {
                 return if self.enabled_modules.contains(module_name) {
                     Ok(ControlFlow::Continue)
@@ -719,6 +758,20 @@ impl<'p> Context<'p> {
                     .checked_div(rhs)
                     .ok_or(RuntimeErrorKind::DivByZero(lhs))?;
                 self.stack.push_this(r);
+            }
+            "/?" => {
+                let rhs = stack_pop!(
+                    (self.stack) -> num as "rhs" for fn_name
+                )?;
+                let lhs = stack_pop!(
+                    (self.stack) -> num as "lhs" for fn_name
+                )?;
+                let r = lhs
+                    .checked_div(rhs)
+                    .ok_or("Division by zero".to_string())
+                    .map(Value::Num)
+                    .map_err(Value::Str);
+                self.stack.push_this(Value::Result(Box::new(r)));
             }
             "./" => {
                 let rhs = stack_pop!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -708,6 +708,27 @@ impl<'p> Context<'p> {
                 )?;
                 self.stack.push_this(lhs * rhs);
             }
+            "/" => {
+                let rhs = stack_pop!(
+                    (self.stack) -> num as "rhs" for fn_name
+                )?;
+                let lhs = stack_pop!(
+                    (self.stack) -> num as "lhs" for fn_name
+                )?;
+                let r = lhs
+                    .checked_div(rhs)
+                    .ok_or(RuntimeErrorKind::DivByZero(lhs))?;
+                self.stack.push_this(r);
+            }
+            "./" => {
+                let rhs = stack_pop!(
+                    (self.stack) -> float as "rhs" for fn_name
+                )?;
+                let lhs = stack_pop!(
+                    (self.stack) -> float as "lhs" for fn_name
+                )?;
+                self.stack.push_this(lhs / rhs);
+            }
             "≃" => {
                 use Value::*;
                 let rhs = stack_pop!((self.stack) -> * as "rhs" for fn_name)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -797,6 +797,12 @@ impl<'p> Context<'p> {
                     }
                 }
             }
+            "try-get" => {
+                let name = stack_pop!(
+                    (self.stack) -> str as "name" for fn_name
+                )?;
+                self.stack.push_this(self.find_var(&name).cloned());
+            }
 
             // seq error handeling
             "!" => {

--- a/src/token.rs
+++ b/src/token.rs
@@ -44,7 +44,7 @@ macro_rules! matches {
         'a'..='z' | 'A'..='Z' | '_' | '-' | '&'
     };
     (ident) => {
-        (matches!(start_ident) | matches!(digit) | '/' | '\'' | '-')
+        (matches!(start_ident) | matches!(digit) | '\'' | '-')
     };
     (arg_type) => {
         (matches!(letter) | matches!(space) | '?' | '*')
@@ -53,7 +53,7 @@ macro_rules! matches {
         'a'..='z' | 'A'..='Z'
     };
     (start_ident) => {
-        'a'..='z' | 'A'..='Z' | '+' | '_' | '%' | '!' | '?' | '$' | '=' | '*' | '&' | '<' | '>' | '≃' | ',' | ':' | '~' | '@' | '.'
+        'a'..='z' | 'A'..='Z' | '+' | '_' | '%' | '!' | '?' | '$' | '=' | '/' | '*' | '&' | '<' | '>' | '≃' | ',' | ':' | '~' | '@' | '.'
     };
     (word_edge) => {
         '(' | ')' | '{' | '}' | '[' | ']'

--- a/src/token.rs
+++ b/src/token.rs
@@ -221,6 +221,7 @@ impl Context {
                         "switch" => RawKeyword::Switch,
                         "break" => RawKeyword::Break,
                         "ifs" => RawKeyword::Ifs,
+                        "try @" => RawKeyword::TryClosure,
                         otherwise => {
                             let include =
                                 otherwise
@@ -255,12 +256,18 @@ impl Context {
                                 .map(str::trim)
                                 .map(String::from)
                                 .map(RawKeyword::Require);
+                            let try_fn = otherwise
+                                .strip_prefix("try ")
+                                .map(str::trim)
+                                .map(String::from)
+                                .map(RawKeyword::Try);
                             include
                                 .or(pragma)
                                 .or(fn_into_closure)
                                 .or(trc)
                                 .or(require_old_protected)
                                 .or(require)
+                                .or(try_fn)
                                 .ok_or(StckError::UnknownKeyword(otherwise.to_string()))?
                         }
                     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -532,7 +532,7 @@ impl From<&Value> for TypeTester {
             }
             Value::Map(_) => todo!("map"),
             Value::Array(_) => todo!("array"),
-            Value::Result(_) => todo!("result"),
+            Value::Result(v) => todo!("result {v:?}"),
             Value::Option(a) => a
                 .clone()
                 .map(|tt| TypeTester::from(tt.as_ref()))

--- a/usage/src/interpreter/main.rs
+++ b/usage/src/interpreter/main.rs
@@ -1,13 +1,22 @@
 use stck::prelude::*;
 
-fn main() -> Result<(), stck::Error> {
+fn exec_file(
+    ctx: &mut stck::internals::HostContext,
+    file_path: String,
+    file_cacher: &mut CacheHelper,
+) -> Result<(), stck::Error> {
+    ctx.execute_entire_code(&get_project_code(file_path, file_cacher)?)?;
+    Ok(())
+}
+
+fn main() -> std::process::ExitCode {
     let file_path = std::env::args().nth(1).unwrap();
     let mut file_cacher = CacheHelper::new();
     let mut exec_ctx = RuntimeContext::new();
-    exec_ctx.register_modules(internals::module::io::make());
-    let code = get_project_code(file_path, &mut file_cacher)?;
-    if let Err(e) = exec_ctx.execute_entire_code(&code) {
+    if let Err(e) = exec_file(&mut exec_ctx, file_path, &mut file_cacher) {
         println!("{e}");
+        std::process::ExitCode::from(1)
+    } else {
+        std::process::ExitCode::from(0)
     }
-    Ok(())
 }


### PR DESCRIPTION
`(try {fn name})` and `(try @)` execute a function or a closure and return a
result that, in case of a runtime error, stores the description of the error.

Closes #228

- **stdlib/vars: set global var**
- **runtime: try-get returns and optional instead of erroring**
- **implement division**
- **(try fn) keyword**
- **testing (try) for functions and closures**
